### PR TITLE
fix: correct Predis transaction pattern in Storage::get_cache()

### DIFF
--- a/src/Core/Storage.php
+++ b/src/Core/Storage.php
@@ -267,10 +267,10 @@ final class Storage {
 			$this->client->transaction(
 				function ( $tx ) use ( $key, &$cache, &$lock_status ) {
 					// Get cache entry.
-					$cache = $this->client->hgetall( $key );
+					$cache = $tx->hgetall( $key );
 
 					// Get lock status.
-					$lock_status = $this->client->get( $key . '-lock' );
+					$lock_status = $tx->get( $key . '-lock' );
 				}
 			);
 


### PR DESCRIPTION
## Problem

The `get_cache()` method was calling `$this->client->hgetall()` and `$this->client->get()` inside a Predis transaction callback, instead of using the `$tx` parameter that gets passed to the callback.

This caused:
- TypeError: `array_keys()` got a `Predis\Response\Status` object instead of an array
- Redis errors: "ERR MULTI calls can not be nested"

## Fix

Changed lines 270 and 273 to use `$tx->` instead of `$this->client->`:

```php
// Before
$cache = $this->client->hgetall( $key );
$lock_status = $this->client->get( $key . '-lock' );

// After
$cache = $tx->hgetall( $key );
$lock_status = $tx->get( $key . '-lock' );
```

This makes `get_cache()` consistent with `set_cache()` and `delete_cache()`, which already use the `$tx` parameter correctly.

## Why this matters

When you call `$this->client->transaction(function($tx) {...})`, Predis passes a transaction object as `$tx`. Inside the callback, you need to call Redis commands on `$tx`, not on `$this->client`. 

Commands on `$tx` get queued and executed atomically. Commands on `$this->client` try to execute immediately, which breaks the transaction and returns wrong data types.