### PR TITLE
fix(ci): Find previous release commit using GitHub API timestamp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,11 +139,28 @@ jobs:
           PREV_TAG="${{ steps.previous.outputs.tag }}"
           REPO="${{ github.repository }}"
 
-          # Get commits since last tag
+          # Get commits since last release
+          # Note: Release tags point to orphan dist branches, not main.
+          # We need to find the main branch commit at the time of the previous release.
           if [ -z "$PREV_TAG" ]; then
             RANGE="HEAD"
           else
-            RANGE="${PREV_TAG}..HEAD"
+            # Get the previous release creation timestamp
+            PREV_RELEASE_TIME=$(gh api "repos/${REPO}/releases/tags/${PREV_TAG}" --jq '.created_at' 2>/dev/null || echo "")
+
+            if [ -n "$PREV_RELEASE_TIME" ]; then
+              # Find the commit on main at that time
+              PREV_COMMIT=$(gh api "repos/${REPO}/commits?sha=main&until=${PREV_RELEASE_TIME}&per_page=1" --jq '.[0].sha' 2>/dev/null || echo "")
+            fi
+
+            if [ -n "$PREV_COMMIT" ]; then
+              RANGE="${PREV_COMMIT}..HEAD"
+              echo "Using commit range: ${PREV_COMMIT:0:7}..HEAD (based on ${PREV_TAG} release time)"
+            else
+              # Fallback: try using tag directly (works if tags are on main ancestry)
+              RANGE="${PREV_TAG}..HEAD"
+              echo "Fallback: using tag range ${PREV_TAG}..HEAD"
+            fi
           fi
 
           # Initialize changelog sections


### PR DESCRIPTION
## Summary

- Fixes changelog including commits from previous releases
- Follows up on #22 which fixed the previous tag detection but not the commit range

## Problem

Even with the correct previous tag, the changelog still showed old commits because:
1. Release tags point to orphan dist branches (for clean distribution)
2. `git log ${PREV_TAG}..HEAD` doesn't work correctly when tags have no common ancestor with main
3. Git ends up showing all commits on main

## Solution

Use the GitHub API to:
1. Get the previous release's creation timestamp
2. Find the commit on main at that time
3. Use that commit for the range instead of the tag

## Test plan

- [ ] Merge and re-run release workflow for v1.0.0-rc.4
- [ ] Verify changelog only shows: #22 fix, #21 features, #20 fix (the actual changes since rc.3)