### PR TITLE
fix(settings): guard apply_filters call for early initialization

### DIFF
--- a/src/Core/Settings.php
+++ b/src/Core/Settings.php
@@ -110,8 +110,8 @@ final class Settings {
 				'prefix' => 'mll',
 			),
 			'cache' => array(
-				'ttl' => DAY_IN_SECONDS,
-				'grace' => MONTH_IN_SECONDS,
+				'ttl' => defined( 'DAY_IN_SECONDS' ) ? DAY_IN_SECONDS : 86400,
+				'grace' => defined( 'MONTH_IN_SECONDS' ) ? MONTH_IN_SECONDS : 2592000,
 				'unique' => array(),
 				'nocache_paths' => array(),
 				'nocache_cookies' => array( 'wp-*pass*', 'comment_author_*' ),


### PR DESCRIPTION
## Summary

- Guard `apply_filters()` call with `function_exists()` check in `get_default_settings()`
- Allows the method to be called before WordPress loads (e.g., in Bedrock's `config/application.php`)
- Enables Acorn/Bedrock projects to dynamically read MilliCache defaults without hardcoding values
- Fully backward compatible - filter still works when WordPress is loaded

## Test plan

- [x] Tested calling `get_default_settings()` from Bedrock `application.php` (before WordPress loads)
- [x] Verified filter hook still works in normal WordPress context
- [x] Confirmed all default values preserved exactly