### PR TITLE
fix: correct path to Predis autoloader in deps directory

### DIFF
--- a/src/Core/Storage.php
+++ b/src/Core/Storage.php
@@ -177,7 +177,7 @@ class Storage {
 	 */
 	private function connect(): bool {
 		if ( ! self::is_available() ) {
-			require_once dirname( __DIR__, 2 ) . '/src/Deps/Predis/Autoloader.php';
+			require_once dirname( __DIR__, 2 ) . '/deps/predis/predis/src/Autoloader.php';
 		}
 
 		try {


### PR DESCRIPTION
## Summary

Fixes incorrect file path to Predis autoloader in .

## Problem

The code was pointing to  which doesn't exist. Strauss places scoped dependencies in  following Composer's vendor/package structure.

## Solution

Changed path to  (the correct location).

## Impact

This bug only manifests when the Autoloader class hasn't been loaded by Composer's classmap autoloader yet (e.g., standalone installations).

## Testing

- ✅ Tested locally with 
- ✅ Verified file exists at correct path
- ✅ Plugin activates and runs successfully