### PR TITLE
fix(admin): Keep cache section collapsed by default

### DIFF
--- a/src/Admin/UI.php
+++ b/src/Admin/UI.php
@@ -414,7 +414,7 @@ final class UI {
 			'id'           => 'cache',
 			'title'        => __( 'Cache Settings', 'millicache' ),
 
-			'open'         => 'ok',
+			'open'         => false,
 			'status'       => array(
 				'key' => 'storage.connected',
 				'ok'  => true,


### PR DESCRIPTION
The Cache Settings panel currently uses `'open' => 'ok'`, which auto-expands it whenever storage is connected — i.e. on every healthy admin load. The panel hosts routine config (TTL, no-cache cookies, ignored keys, etc.) that's set once and rarely revisited, so default-open surfaces it as noise on every page load instead of focus.

Switching to `'open' => false` keeps the status badge intact (Connected pill still renders via the `status` property) but stops the panel from auto-expanding. Storage Server's `'open' => 'error'` is unchanged — it still pops open when storage is actually broken, since that's a state the user needs to act on.

Verified locally on millipress.test via a Composer path-repo override in millicache-pro: pill renders correctly in the section header; panel stays collapsed by default; Storage Server's auto-open-on-error behavior is unaffected.