### PR TITLE
chore(js): migrate from legacy isLoading alias to specific atoms

### DIFF
--- a/assets/js/settings/partials/ClearCacheButton.jsx
+++ b/assets/js/settings/partials/ClearCacheButton.jsx
@@ -8,7 +8,8 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const ClearCacheButton = ( { status, triggerAction, isSaving, isLoading } ) => {
+const ClearCacheButton = ( { status, triggerAction, isSaving } ) => {
+	const { isLoadingAction } = window.MilliBase.hooks.useSettings();
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ targets, setTargets ] = useState( [] );
 
@@ -36,7 +37,7 @@ const ClearCacheButton = ( { status, triggerAction, isSaving, isLoading } ) => {
 				onClick={ () => setIsModalOpen( true ) }
 				disabled={
 					isSaving ||
-					isLoading ||
+					isLoadingAction ||
 					! status.storage?.connected ||
 					status.cache?.index < 1
 				}

--- a/assets/js/settings/tabs/Status.jsx
+++ b/assets/js/settings/tabs/Status.jsx
@@ -1,7 +1,8 @@
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const StatusTab = ( { status, isLoading } ) => {
+const StatusTab = ( { status } ) => {
+	const { isLoadingSettings } = window.MilliBase.hooks.useSettings();
 	const connectionInfo = {
 		[ __( 'Status', 'millicache' ) ]: status.storage?.connected
 			? __( 'Connected', 'millicache' )
@@ -65,7 +66,7 @@ const StatusTab = ( { status, isLoading } ) => {
 
 	return (
 		<div>
-			{ isLoading && <Spinner /> }
+			{ isLoadingSettings && <Spinner /> }
 			{ status && (
 				<>
 					<h2>{ __( 'Connection', 'millicache' ) }</h2>


### PR DESCRIPTION
## Summary

Migrates all MC Free JS components off the legacy `isLoading` alias (`isLoadingSettings || isLoadingAction`) that will be removed from `MilliBase.hooks.useSettings()` in the upcoming MilliBase cleanup PR.

Both components now call `window.MilliBase.hooks.useSettings()` directly and pull the specific atom they need.

## Files changed (2) — 2 `isLoading` references removed

### `assets/js/settings/tabs/Status.jsx`
- **Removed** `isLoading` from props signature.
- **Added** `const { isLoadingSettings } = window.MilliBase.hooks.useSettings();`
- **Replaced** `{ isLoading && <Spinner /> }` → `{ isLoadingSettings && <Spinner /> }`
- **Rule applied**: page-level loading guard (spinner shown only during the first-mount settings fetch).

### `assets/js/settings/partials/ClearCacheButton.jsx`
- **Removed** `isLoading` from props signature.
- **Added** `const { isLoadingAction } = window.MilliBase.hooks.useSettings();`
- **Replaced** `isLoading` in the `disabled` expression → `isLoadingAction`
- **Rule applied**: in-flight action busy (button must stay disabled while any action counter > 0, regardless of initial settings load).

## Ambiguous / skipped

None. Both call sites mapped cleanly to a single rule.

## Notes

- `isSaving` remains a prop on `ClearCacheButton` — `saveSettings` does not go through `withLoading`, so `isSaving` and `isLoadingAction` are independent flags and both are still needed.
- Once this PR and the MC Pro sweep PR are merged, the MilliBase `isLoading` alias and its `Header`/`TabRenderer` plumbing can be removed safely.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S31AwjGT6Z2n9hwTTYRPra)_