### PR TITLE
feat(cache): Bucket framework with content-addressable body dedup

### DIFF
--- a/docs/02-configuration/01-overview.md
+++ b/docs/02-configuration/01-overview.md
@@ -102,6 +102,15 @@ What to skip:
 | `MC_CACHE_IGNORE_COOKIES`      | `['_*']`          | Cookies stripped from key |
 | `MC_CACHE_IGNORE_REQUEST_KEYS` | `['_*', 'utm_*']` | Query params to ignore    |
 
+### Key Composition Settings
+
+How cache entries differentiate from each other:
+
+| Constant            | Default | Description                                                                |
+|---------------------|---------|----------------------------------------------------------------------------|
+| `MC_CACHE_UNIQUE`   | `[]`    | Static deployment-level keys folded into every request hash                |
+| `MC_CACHE_BUCKETS`  | `[]`    | Per-request signal → token map (Accept negotiation, language, device, …) |
+
 ## Common Configurations
 
 ### High-Traffic Site

--- a/docs/02-configuration/02-reference.md
+++ b/docs/02-configuration/02-reference.md
@@ -213,14 +213,44 @@ define( 'MC_CACHE_UNIQUE', [] );
 | Default   | `[]`    |
 | Type      | `array` |
 
-Variables that make cache entries unique. Each combination creates a separate entry.
+Static cache namespace — values folded into every request hash on this deployment. Use for deploy-time cache busting or multi-site isolation.
 
 ```php
-define( 'MC_CACHE_UNIQUE', [ 'device', 'currency' ] );
+define( 'MC_CACHE_UNIQUE', [ 'version' => '2.1', 'site_id' => 5 ] );
 ```
 
-> [!WARNING]
-> Overuse can lead to cache fragmentation and reduced hit rates. Use with caution.
+> [!TIP]
+> For per-request differentiation, use `MC_CACHE_BUCKETS` instead.
+
+### MC_CACHE_BUCKETS
+
+```php
+define( 'MC_CACHE_BUCKETS', [] );
+```
+
+| Property  | Value                                       |
+|-----------|---------------------------------------------|
+| Default   | `[]`                                        |
+| Type      | `array<string, array<string, string>>`      |
+
+Shared lookup tables for bucket resolvers. Each top-level key names a request *dimension*; the inner map translates raw request values into compact bucket tokens.
+
+```php
+define( 'MC_CACHE_BUCKETS', [
+    'accept' => [ 'text/markdown' => 'md' ],
+    'tenant' => [ 'acme' => 'acme', 'globex' => 'glx' ],
+] );
+```
+
+Two built-in resolvers ship in MilliCache:
+
+- **`auth`** — Authorization header. Always-on correctness primitive: each unique bearer token gets its own cache entry. No config needed.
+- **`accept`** — Accept header content negotiation. Dormant unless `MC_CACHE_BUCKETS['accept']` is configured. Parses with q-values and looks up the top-preferred MIME type.
+
+Other dimensions need a resolver implementation. See [Bucket Extension](../07-developers/02-hooks-filters.md#bucket-extension) — the rules engine's `set_bucket` action is the no-code way to add them.
+
+> [!NOTE]
+> Bucket tokens should be short — they're folded into the cache key. `md`, `de`, `mobile` are good; full MIME types or full UA strings are not.
 
 ### MC_CACHE_NOCACHE_PATHS
 

--- a/docs/04-rules/02-built-in-rules.md
+++ b/docs/04-rules/02-built-in-rules.md
@@ -108,11 +108,12 @@ This means:
 
 Available in `php` rules (before WordPress):
 
-| Action                       | Description            | Example                          |
-|------------------------------|------------------------|----------------------------------|
-| `do_cache( $bool, $reason )` | Enable/disable caching | `->do_cache( false, 'Preview' )` |
-| `set_ttl( $seconds )`        | Override TTL           | `->set_ttl( 3600 )`              |
-| `set_grace( $seconds )`      | Override grace period  | `->set_grace( 86400 )`           |
+| Action                          | Description                 | Example                                |
+|---------------------------------|-----------------------------|----------------------------------------|
+| `do_cache( $bool, $reason )`    | Enable/disable caching      | `->do_cache( false, 'Preview' )`       |
+| `set_ttl( $seconds )`           | Override TTL                | `->set_ttl( 3600 )`                    |
+| `set_grace( $seconds )`         | Override grace period       | `->set_grace( 86400 )`                 |
+| `set_bucket( $name, $token )`   | Add a bucket to the hash    | `->set_bucket( 'device', 'mobile' )`   |
 
 ### WordPress Phase Actions
 

--- a/docs/05-usage/10-how-caching-works.md
+++ b/docs/05-usage/10-how-caching-works.md
@@ -50,13 +50,16 @@ If caching proceeds, MilliCache generates a **cache key** from:
 
 - Request URL (path and query string)
 - Cookies (excluding ignored ones)
-- Custom unique variables (if configured)
+- Custom unique variables (`MC_CACHE_UNIQUE`)
+- Resolved request **buckets** — short tokens for per-request signals (Authorization is built-in; others can be added via rules)
 
 The key is hashed and used to look up cached content in Redis:
 
 ```
-Cache Key = hash( URL + filtered_cookies + unique_vars )
+Cache Key = hash( URL + filtered_cookies + unique_vars + buckets )
 ```
+
+Buckets handle dimensions that vary *per request*; `unique_vars` provides static deployment-level isolation. See [`MC_CACHE_BUCKETS`](../02-configuration/02-reference.md#mc_cache_buckets) and [Bucket Extension](../07-developers/02-hooks-filters.md#bucket-extension).
 
 ### 4. Cache Hit
 
@@ -94,17 +97,27 @@ This ensures visitors never wait for page generation.
 
 ## Cache Storage Structure
 
-Each cache entry contains:
+Each cache entry is split across two Redis keyspaces: the **request entry** holds per-request metadata; the **output entry** holds the response body and is content-addressable, so identical bodies across variants share storage.
 
-| Component   | Description           |
-|-------------|-----------------------|
-| `content`   | Full HTML response    |
-| `headers`   | HTTP response headers |
-| `flags`     | Tags for invalidation |
-| `created`   | Timestamp when cached |
-| `ttl`       | Time-to-live value    |
-| `grace`     | Grace period value    |
-| `gzip`      | Compression status    |
+| Keyspace | Key shape                       | Holds                                                                  |
+|----------|---------------------------------|------------------------------------------------------------------------|
+| Request  | `<prefix>:c:<request_hash>`     | Headers, status, flags, variant meta, `output_ref` (sha1 pointer)      |
+| Output   | `<prefix>:o:<output_hash>`      | Response body bytes (compressed if gzip is enabled)                    |
+| Refs     | `<prefix>:o:<output_hash>:refs` | Redis SET of request keys referencing this body                        |
+
+The reference SET tracks who's pointing at each body so it can be garbage-collected when the last referrer is removed. Variants that genuinely differ get their own body; identical bodies across variants share one.
+
+### Per-entry fields
+
+| Component    | Description                                            |
+|--------------|--------------------------------------------------------|
+| `output_ref` | SHA-1 pointer to the body in the output keyspace       |
+| `headers`    | HTTP response headers                                  |
+| `status`     | HTTP status code                                       |
+| `flags`      | Tags for invalidation                                  |
+| `variant`    | Differentiating dimensions (cookies, buckets, method)  |
+| `updated`    | Timestamp when cached                                  |
+| `gzip`       | Whether the body bytes are compressed                  |
 
 ### Flags (Tags)
 

--- a/docs/07-developers/01-architecture.md
+++ b/docs/07-developers/01-architecture.md
@@ -159,6 +159,20 @@ $storage->is_connected();
 $storage->get_status();
 ```
 
+#### Two-keyspace layout
+
+The Storage layer splits each cache entry into two Redis hashes plus a reference set:
+
+| Keyspace                  | Purpose                                                              |
+|---------------------------|----------------------------------------------------------------------|
+| `<prefix>:c:<hash>`       | Request entry — headers, status, flags, variant, `output_ref` (sha1) |
+| `<prefix>:o:<hash>`       | Body bytes, content-addressable, deduplicated across variants        |
+| `<prefix>:o:<hash>:refs`  | SET of request entries referencing this body                         |
+
+`set_cache()` writes the body to `o:<hash>` (no-op if present), `SADD`s the request key into the refs SET, and stores the SHA-1 in the request entry's `output` field. `get_cache()` follows the pointer to the body. `delete_cache()` decrements the refs SET; the body is GC'd when SCARD hits zero.
+
+The split is invisible at the cache-layer API: `Reader`, `Writer`, and `Manager` work with regular `Entry` value objects.
+
 ### Settings
 
 Configuration management via MilliBase, accessed through the Engine singleton.

--- a/docs/07-developers/02-hooks-filters.md
+++ b/docs/07-developers/02-hooks-filters.md
@@ -250,6 +250,51 @@ add_filter( 'millicache_settings_clear_site_options', function( $options ) {
 
 ---
 
+### Bucket Extension
+
+Buckets are short canonical tokens folded into the cache key to differentiate per-request signals. MilliCache does **not** expose a runtime hook filter for buckets — `advanced-cache.php` runs before any plugin or mu-plugin loads, so a `add_filter()` callback registered on `plugins_loaded` would never run during cache lookup. The lookup hash and the write hash would diverge, producing a permanent cache miss.
+
+Buckets are extended through two paths whose timing matches MilliCache's boot order:
+
+#### Static bucket configuration
+
+Lookup tables for resolvers go in the [`MC_CACHE_BUCKETS`](../02-configuration/02-reference.md#mc_cache_buckets) constant. Read during Config construction, available when the cache key is generated.
+
+```php
+define( 'MC_CACHE_BUCKETS', [
+    'tenant' => [ 'acme' => 'acme', 'globex' => 'glx' ],
+    'ab'     => [ 'control' => 'a', 'variant' => 'b' ],
+] );
+```
+
+Defining a lookup table doesn't bucket anything by itself; a *resolver* still has to read the table and call `add_bucket()`.
+
+#### Runtime bucket extension via the rules engine
+
+For per-request bucket resolution that depends on conditions (URL match, header presence, cookie value, etc.), use the **rules engine**. Rules are evaluated during the early PHP phase, in time to influence the request hash.
+
+The `set_bucket` PHP-phase action calls into:
+
+```php
+\MilliCache\Engine\Request\Bucket\Resolver::add_bucket( string $name, string $token ): void
+```
+
+`add_bucket()` is the programmatic extension point. Programmatic additions take precedence over built-in resolutions when names collide.
+
+Example: bucket A/B test arms from a cookie:
+
+```
+Condition: cookie ab_arm matches /^[ab]$/
+Action:    set_bucket name="ab" token="{cookie:ab_arm}"
+```
+
+The rule fires per request; the action calls `$resolver->add_bucket('ab', $cookie_value)`. Cache entries for arm A and arm B stay distinct, but if the rendered HTML happens to be byte-identical they automatically share storage via the content-addressable output keyspace.
+
+> [!NOTE]
+> Regular WordPress plugins cannot extend buckets at the cache-lookup phase because they load after `advanced-cache.php`. To influence cache differentiation, ship a settings update (extending `MC_CACHE_BUCKETS`) or register rules.
+
+---
+
 ### Request Flags Filters
 
 #### millicache_flags_for_request

--- a/src/Core/Storage.php
+++ b/src/Core/Storage.php
@@ -261,7 +261,8 @@ class Storage {
 	 *
 	 * Returns per-entry data keyed by cache hash, with flags always included.
 	 * By default, only reads the small meta-field; set $include_output to also
-	 * transfer the (potentially large) output field.
+	 * transfer the (potentially large) output body, which is dereferenced from
+	 * the content-addressable output keyspace.
 	 *
 	 * @since 1.4.0
 	 * @access public
@@ -284,16 +285,14 @@ class Storage {
 				return array();
 			}
 
-			$by_flag      = ! empty( $flag );
-			$hmget_fields = $include_output ? array( 'meta', 'output' ) : array( 'meta' );
-			$flag_prefix  = $this->prefix . ':f:';
+			$by_flag     = ! empty( $flag );
+			$flag_prefix = $this->prefix . ':f:';
 
 			$results = $this->client->pipeline(
-				function ( $pipe ) use ( $keys, $hmget_fields, $by_flag ) {
+				function ( $pipe ) use ( $keys, $by_flag ) {
 					foreach ( $keys as $key ) {
 						$full_key = $by_flag ? $this->toggle_cache_key( $key ) : $key;
-						$pipe->hmget( $full_key, $hmget_fields );
-						$pipe->hstrlen( $full_key, 'output' );
+						$pipe->hmget( $full_key, array( 'meta', 'output' ) );
 						$pipe->hkeys( $full_key );
 					}
 				}
@@ -303,33 +302,70 @@ class Storage {
 				return array();
 			}
 
-			$entries = array();
-
+			// Phase 1: collect output hashes per entry.
+			$entries       = array();
+			$output_hashes = array();
 			foreach ( $keys as $i => $key ) {
-				$values   = $results[ $i * 3 ] ?? null;
-				$size     = $results[ $i * 3 + 1 ] ?? 0;
-				$all_keys = $results[ $i * 3 + 2 ] ?? array();
+				$values   = $results[ $i * 2 ] ?? null;
+				$all_keys = $results[ $i * 2 + 1 ] ?? array();
 
 				if ( ! is_array( $values ) || ! is_string( $values[0] ?? null ) ) {
 					continue;
 				}
 
 				$entry         = $this->parse_meta( $values[0] );
-				$entry['size'] = is_numeric( $size ) ? (int) $size : 0;
+				$output_hash   = isset( $values[1] ) && is_string( $values[1] ) ? $values[1] : '';
+				$entry['size'] = 0;
 
-				if ( $include_output ) {
-					$entry['output'] = $values[1] ?? '';
-				}
-
-				// Extract flags from hash keys.
 				$entry['flags'] = array_map(
 					array( $this, 'toggle_flag_key' ),
 					is_array( $all_keys ) ? array_filter( $all_keys, fn( $k ) => is_string( $k ) && strpos( $k, $flag_prefix ) === 0 ) : array()
 				);
 
-				// Keys from the pattern scan are full keys; from the flag lookup are hashes.
 				$hash             = $by_flag ? $key : $this->toggle_cache_key( $key );
 				$entries[ $hash ] = $entry;
+
+				if ( '' !== $output_hash ) {
+					$output_hashes[ $hash ] = $output_hash;
+				}
+			}
+
+			if ( empty( $output_hashes ) ) {
+				return $entries;
+			}
+
+			// Phase 2: pipeline-fetch sizes (and bodies if requested) for unique hashes.
+			$unique_hashes = array_values( array_unique( $output_hashes ) );
+			$body_results  = $this->client->pipeline(
+				function ( $pipe ) use ( $unique_hashes, $include_output ) {
+					foreach ( $unique_hashes as $output_hash ) {
+						$pipe->hstrlen( $this->output_key( $output_hash ), 'output' );
+						if ( $include_output ) {
+							$pipe->hget( $this->output_key( $output_hash ), 'output' );
+						}
+					}
+				}
+			);
+
+			$stride       = $include_output ? 2 : 1;
+			$hash_sizes   = array();
+			$hash_outputs = array();
+			if ( is_array( $body_results ) ) {
+				foreach ( $unique_hashes as $i => $output_hash ) {
+					$size                       = $body_results[ $i * $stride ] ?? 0;
+					$hash_sizes[ $output_hash ] = is_numeric( $size ) ? (int) $size : 0;
+					if ( $include_output ) {
+						$body                         = $body_results[ $i * $stride + 1 ] ?? '';
+						$hash_outputs[ $output_hash ] = is_string( $body ) ? $body : '';
+					}
+				}
+			}
+
+			foreach ( $output_hashes as $entry_hash => $output_hash ) {
+				$entries[ $entry_hash ]['size'] = $hash_sizes[ $output_hash ] ?? 0;
+				if ( $include_output ) {
+					$entries[ $entry_hash ]['output'] = $hash_outputs[ $output_hash ] ?? '';
+				}
 			}
 
 			return $entries;
@@ -415,8 +451,20 @@ class Storage {
 				return null;
 			}
 
+			// "output" field holds the output_hash; resolve to bytes.
+			$output_hash = (string) $cache['output'];
+			$output      = '';
+			if ( '' !== $output_hash ) {
+				$body = $this->client->hget( $this->output_key( $output_hash ), 'output' );
+				if ( ! is_string( $body ) ) {
+					// Body GC'd or missing — miss.
+					return null;
+				}
+				$output = $body;
+			}
+
 			$data           = $this->parse_meta( $cache['meta'] ?? '{}' );
-			$data['output'] = $cache['output'];
+			$data['output'] = $output;
 
 			return array(
 				$data,
@@ -431,6 +479,13 @@ class Storage {
 
 	/**
 	 * Set cache.
+	 *
+	 * Stores the response body in a content-addressable keyspace
+	 * (`<prefix>:o:<output_hash>`) and points the request entry's `output`
+	 * field at that hash. Multiple variants whose bodies hash to the same
+	 * value automatically share storage; a Redis SET tracks referencing
+	 * request keys so the body can be garbage-collected when the last
+	 * referrer is removed.
 	 *
 	 * @since 1.0.0
 	 * @access public
@@ -457,7 +512,14 @@ class Storage {
 			 */
 			do_action( 'millicache_entry_storing', $hash, $key, $flags, $data );
 
-			// Build metadata blob.
+			// Hash the body for the content-addressable keyspace.
+			$output      = isset( $data['output'] ) && is_string( $data['output'] ) ? $data['output'] : '';
+			$output_hash = '' === $output ? '' : sha1( $output );
+
+			// Read previous hash so we can release its reference if it's changing.
+			$existing_output_hash = (string) ( $this->client->hget( $key, 'output' ) ?? '' );
+
+			// Build metadata blob; output bytes live at output_key, not inline.
 			$meta = array(
 				'headers' => $data['headers'] ?? array(),
 				'status'  => $data['status'] ?? 200,
@@ -480,7 +542,7 @@ class Storage {
 			}
 
 			$fields = array(
-				'output' => $data['output'] ?? '',
+				'output' => $output_hash,
 				'meta'   => (string) wp_json_encode( $meta ),
 			);
 
@@ -502,16 +564,22 @@ class Storage {
 			// Determine which ones to remove.
 			$stale_flag_fields = array_diff( $existing_flag_fields, $flag_keys );
 
+			$config = Engine::instance()->config();
+			$ttl    = ( $meta['custom_ttl'] ?? $config->ttl ) + ( $meta['custom_grace'] ?? $config->grace ) + 3;
+
+			$output_key   = '' === $output_hash ? '' : $this->output_key( $output_hash );
+			$output_refs  = '' === $output_hash ? '' : $this->output_refs_key( $output_hash );
+
 			// Execute the transaction.
 			$this->client->transaction(
-				function ( $tx ) use ( $key, $flag_keys, $fields, $meta, $stale_flag_fields ) {
+				function ( $tx ) use ( $key, $flag_keys, $fields, $stale_flag_fields, $ttl, $output_key, $output_refs, $output_hash, $output ) {
 					// Remove stale flag fields and their flag-set memberships.
 					foreach ( $stale_flag_fields as $stale_flag_field ) {
 						$tx->hdel( $key, array( $stale_flag_field ) );
 						$tx->srem( $stale_flag_field, array( $key ) );
 					}
 
-					// Store the fields.
+					// Store the request entry fields.
 					$tx->hmset( $key, $fields );
 
 					// Add key to flag sets.
@@ -519,11 +587,22 @@ class Storage {
 						$tx->sadd( $flag_key, array( $key ) );
 					}
 
-					// Set the max expiration time, respecting per-entry overrides.
-					$config = Engine::instance()->config();
-					$tx->expire( $key, ( $meta['custom_ttl'] ?? $config->ttl ) + ( $meta['custom_grace'] ?? $config->grace ) + 3 );
+					// Write the body keyspace if there is any output.
+					if ( '' !== $output_hash ) {
+						$tx->hsetnx( $output_key, 'output', $output );
+						$tx->sadd( $output_refs, array( $key ) );
+						$tx->expire( $output_key, $ttl );
+						$tx->expire( $output_refs, $ttl );
+					}
+
+					$tx->expire( $key, $ttl );
 				}
 			);
+
+			// Release the old body reference if the hash changed.
+			if ( '' !== $existing_output_hash && $existing_output_hash !== $output_hash ) {
+				$this->release_output( $existing_output_hash, $key );
+			}
 
 			/**
 			 * Fires after a cache entry is stored in the storage server.
@@ -557,14 +636,15 @@ class Storage {
 		try {
 			$key = $this->toggle_cache_key( $hash );
 
-			// Get all fields of the key and filter to flag fields only.
-			$fields = $this->client->hkeys( $key );
+			// Read fields up front so we can release the body reference after deletion.
+			$entry_fields = $this->client->hgetall( $key );
 
-			if ( ! is_array( $fields ) ) {
+			if ( ! is_array( $entry_fields ) || empty( $entry_fields ) ) {
 				return false;
 			}
 
-			$flags = $this->filter_flag_fields( $fields );
+			$flags       = $this->filter_flag_fields( array_keys( $entry_fields ) );
+			$output_hash = isset( $entry_fields['output'] ) ? (string) $entry_fields['output'] : '';
 
 			/**
 			 * Fires before a cache entry is deleted in the storage server.
@@ -595,6 +675,9 @@ class Storage {
 				}
 			);
 
+			// Release the body reference; GC if it was the last referrer.
+			$this->release_output( $output_hash, $key );
+
 			/**
 			 * Fires after a cache entry is deleted in the storage server.
 			 *
@@ -610,6 +693,63 @@ class Storage {
 		} catch ( PredisException $e ) {
 			error_log( 'Unable to delete cache in the storage server: ' . $e->getMessage() );
 			return false;
+		}
+	}
+
+	/**
+	 * Build the Redis key for a body in the output keyspace.
+	 *
+	 * @since 1.6.0
+	 * @access private
+	 *
+	 * @param string $output_hash The body's content hash.
+	 * @return string The fully prefixed key.
+	 */
+	private function output_key( string $output_hash ): string {
+		return $this->prefix . ':o:' . $output_hash;
+	}
+
+	/**
+	 * Build the Redis key for a body's reference set.
+	 *
+	 * @since 1.6.0
+	 * @access private
+	 *
+	 * @param string $output_hash The body's content hash.
+	 * @return string The fully prefixed reference set key.
+	 */
+	private function output_refs_key( string $output_hash ): string {
+		return $this->output_key( $output_hash ) . ':refs';
+	}
+
+	/**
+	 * Release one referrer from a body and GC the body if it's the last one.
+	 *
+	 * Idempotent: a no-op when the hash is empty or the referrer isn't a member.
+	 *
+	 * @since 1.6.0
+	 * @access private
+	 *
+	 * @param string $output_hash The body's content hash.
+	 * @param string $referrer    The cache key that previously referenced it.
+	 * @return void
+	 */
+	private function release_output( string $output_hash, string $referrer ): void {
+		if ( '' === $output_hash ) {
+			return;
+		}
+
+		$output_key  = $this->output_key( $output_hash );
+		$output_refs = $this->output_refs_key( $output_hash );
+
+		try {
+			$this->client->srem( $output_refs, array( $referrer ) );
+			$remaining = $this->client->scard( $output_refs );
+			if ( 0 === (int) $remaining ) {
+				$this->client->del( array( $output_key, $output_refs ) );
+			}
+		} catch ( PredisException $e ) {
+			error_log( 'Unable to release body reference in the storage server: ' . $e->getMessage() );
 		}
 	}
 
@@ -976,6 +1116,10 @@ class Storage {
 	/**
 	 * Get the size of the cache.
 	 *
+	 * Reports logical (per-entry) body size: each entry contributes the byte
+	 * length of the body it points to, even if multiple entries share the same
+	 * body in the deduplicated output keyspace.
+	 *
 	 * @since 1.0.0
 	 * @access public
 	 *
@@ -991,35 +1135,69 @@ class Storage {
 			if ( empty( $keys ) ) {
 				return array(
 					'index' => 0,
-					'size' => 0,
+					'size'  => 0,
 				);
 			}
 
-			$sizes = $this->client->pipeline(
-				function ( $pipe ) use ( $keys, $flag ) {
+			// Phase 1: collect each entry's output_hash.
+			$by_flag       = ! empty( $flag );
+			$output_hashes = $this->client->pipeline(
+				function ( $pipe ) use ( $keys, $by_flag ) {
 					foreach ( $keys as $key ) {
-						$pipe->hstrlen( ! empty( $flag ) ? $this->toggle_cache_key( $key ) : $key, 'output' );
+						$pipe->hget( $by_flag ? $this->toggle_cache_key( $key ) : $key, 'output' );
 					}
 				}
 			);
 
-			if ( ! is_array( $sizes ) ) {
+			if ( ! is_array( $output_hashes ) ) {
 				return array(
 					'index' => count( $keys ),
-					'size' => 0,
+					'size'  => 0,
 				);
 			}
 
-			$valid_sizes = array_filter(
-				$sizes,
-				function ( $size ) {
-					return is_numeric( $size ) && $size > 0;
+			$entry_hashes = array_map( 'strval', $output_hashes );
+			$unique       = array_values( array_unique( array_filter( $entry_hashes ) ) );
+
+			if ( empty( $unique ) ) {
+				return array(
+					'index' => 0,
+					'size'  => 0,
+				);
+			}
+
+			// Phase 2: fetch unique body strlens.
+			$strlens = $this->client->pipeline(
+				function ( $pipe ) use ( $unique ) {
+					foreach ( $unique as $output_hash ) {
+						$pipe->hstrlen( $this->output_key( $output_hash ), 'output' );
+					}
 				}
 			);
 
+			$hash_sizes = array();
+			if ( is_array( $strlens ) ) {
+				foreach ( $unique as $i => $output_hash ) {
+					$hash_sizes[ $output_hash ] = is_numeric( $strlens[ $i ] ?? 0 ) ? (int) $strlens[ $i ] : 0;
+				}
+			}
+
+			$total_size  = 0;
+			$valid_count = 0;
+			foreach ( $entry_hashes as $output_hash ) {
+				if ( '' === $output_hash ) {
+					continue;
+				}
+				$size = $hash_sizes[ $output_hash ] ?? 0;
+				if ( $size > 0 ) {
+					$total_size += $size;
+					++$valid_count;
+				}
+			}
+
 			return array(
-				'index' => count( $valid_sizes ),
-				'size' => (int) array_sum( $valid_sizes ),
+				'index' => $valid_count,
+				'size'  => $total_size,
 			);
 		} catch ( PredisException $e ) {
 			error_log( 'Unable to get cache size from the storage server: ' . $e->getMessage() );

--- a/src/Engine/Cache/Config.php
+++ b/src/Engine/Cache/Config.php
@@ -92,19 +92,30 @@ final class Config {
 	public array $unique;
 
 	/**
+	 * Map of bucket name → (raw value → bucket token).
+	 *
+	 * Shared lookup tables for resolvers to consume when calling
+	 * {@see \MilliCache\Engine\Request\Bucket\Resolver::add_bucket()}.
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	public array $buckets;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param int           $ttl                 Cache time-to-live in seconds.
-	 * @param int           $grace               Grace period in seconds.
-	 * @param bool          $gzip                Whether to use gzip compression.
-	 * @param bool          $debug               Whether debug mode is enabled.
-	 * @param array<string> $nocache_paths       Paths that should not be cached.
-	 * @param array<string> $nocache_cookies     Cookies that prevent caching.
-	 * @param array<string> $ignore_cookies      Cookies to ignore in hash.
-	 * @param array<string> $ignore_request_keys Query keys to ignore.
-	 * @param array<string> $unique              Variables making requests unique.
+	 * @param int                                  $ttl                 Cache time-to-live in seconds.
+	 * @param int                                  $grace               Grace period in seconds.
+	 * @param bool                                 $gzip                Whether to use gzip compression.
+	 * @param bool                                 $debug               Whether debug mode is enabled.
+	 * @param array<string>                        $nocache_paths       Paths that should not be cached.
+	 * @param array<string>                        $nocache_cookies     Cookies that prevent caching.
+	 * @param array<string>                        $ignore_cookies      Cookies to ignore in hash.
+	 * @param array<string>                        $ignore_request_keys Query keys to ignore.
+	 * @param array<string>                        $unique              Variables making requests unique.
+	 * @param array<string, array<string, string>> $buckets             Bucket name → (raw value → token) map.
 	 */
 	public function __construct(
 		int $ttl,
@@ -115,7 +126,8 @@ final class Config {
 		array $nocache_cookies,
 		array $ignore_cookies,
 		array $ignore_request_keys,
-		array $unique
+		array $unique,
+		array $buckets = array()
 	) {
 		$this->ttl                 = $ttl;
 		$this->grace               = $grace;
@@ -126,10 +138,11 @@ final class Config {
 		$this->ignore_cookies      = $ignore_cookies;
 		$this->ignore_request_keys = $ignore_request_keys;
 		$this->unique              = $unique;
+		$this->buckets             = $buckets;
 	}
 
 	/**
-	 * Create config from settings array.
+	 * Create config from the settings array.
 	 *
 	 * @since 1.0.0
 	 *
@@ -146,7 +159,47 @@ final class Config {
 			Helpers::pluck_string_array( $settings, 'nocache_cookies' ),
 			Helpers::pluck_string_array( $settings, 'ignore_cookies' ),
 			Helpers::pluck_string_array( $settings, 'ignore_request_keys' ),
-			Helpers::pluck_string_array( $settings, 'unique' )
+			Helpers::pluck_string_array( $settings, 'unique' ),
+			self::resolve_buckets( $settings )
 		);
+	}
+
+	/**
+	 * Resolve the bucket configuration map from settings.
+	 *
+	 * Returns a nested map of bucket name → (lowercased raw value → token).
+	 * Drops invalid pairs silently. Defaults to an empty map.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param array<string,mixed> $settings Settings array.
+	 * @return array<string, array<string, string>> Nested bucket map.
+	 */
+	private static function resolve_buckets( array $settings ): array {
+		$configured = isset( $settings['buckets'] ) && is_array( $settings['buckets'] )
+			? $settings['buckets']
+			: array();
+
+		$normalized = array();
+		foreach ( $configured as $bucket_name => $tokens ) {
+			if ( ! is_string( $bucket_name ) || ! is_array( $tokens ) ) {
+				continue;
+			}
+
+			$key   = strtolower( trim( $bucket_name ) );
+			$inner = array();
+			foreach ( $tokens as $raw => $token ) {
+				if ( ! is_string( $raw ) || ! is_string( $token ) || '' === $token ) {
+					continue;
+				}
+				$inner[ strtolower( trim( $raw ) ) ] = $token;
+			}
+
+			if ( ! empty( $inner ) ) {
+				$normalized[ $key ] = $inner;
+			}
+		}
+
+		return $normalized;
 	}
 }

--- a/src/Engine/Cache/Reader.php
+++ b/src/Engine/Cache/Reader.php
@@ -67,40 +67,34 @@ final class Reader {
 	/**
 	 * Get cache entry by hash.
 	 *
+	 * The Storage layer is responsible for resolving the request entry's
+	 * `output` field through the content-addressable output keyspace, so the
+	 * Entry returned here always carries the actual body bytes (or empty when
+	 * the response was empty).
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param string $hash The request hash.
-	 * @return Result The cache result (hit, miss, or stale).
+	 * @return Result The cache result (hit or miss).
 	 */
 	public function get( string $hash ): Result {
 		if ( ! $this->storage->is_available() ) {
 			return Result::miss();
 		}
 
-		// Look for an existing cache entry by request hash.
 		$result = $this->storage->get_cache( $hash );
 
-		// No cache found.
 		if ( ! $result ) {
 			return Result::miss();
 		}
 
-		// Unpack the result.
 		list( $cache, $flags, $locked ) = $result;
 
-		// No valid cache data.
 		if ( ! is_array( $cache ) || empty( $cache ) ) {
 			return Result::miss();
 		}
 
-		// Convert to Entry.
-		$entry = Entry::from_array( $cache );
-
-		// Convert locked to boolean (storage returns string).
-		$is_locked = ! empty( $locked );
-
-		// Return cache result with entry and metadata.
-		return Result::hit( $entry, $flags, $is_locked );
+		return Result::hit( Entry::from_array( $cache ), $flags, ! empty( $locked ) );
 	}
 
 	/**

--- a/src/Engine/Request/Bucket/Resolver.php
+++ b/src/Engine/Request/Bucket/Resolver.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Request bucket resolver.
+ *
+ * @link        https://www.millipress.com
+ * @since       1.7.0
+ *
+ * @package     MilliCache
+ * @subpackage  Engine\Request\Bucket
+ * @author      Philipp Wellmer <hello@millipress.com>
+ */
+
+namespace MilliCache\Engine\Request\Bucket;
+
+use MilliCache\Engine\Cache\Config;
+use MilliCache\Engine\Utilities\ServerVars;
+
+! defined( 'ABSPATH' ) && exit;
+
+/**
+ * Resolves request signals into a normalized bucket map.
+ *
+ * Each bucket is a (name, token) pair folded into the request hash so that
+ * requests sharing the same intent map to the same cache entry. Built-in
+ * resolvers handle Authorization (always on, security primitive) and Accept
+ * content negotiation (dormant unless `MC_CACHE_BUCKETS['accept']` is set).
+ * Additional dimensions are added via {@see Resolver::add_bucket()} from
+ * rule actions or other early-phase code.
+ *
+ * @since      1.7.0
+ * @package    MilliCache
+ * @author     Philipp Wellmer <hello@millipress.com>
+ */
+final class Resolver {
+
+	/**
+	 * Cache configuration.
+	 *
+	 * @var Config
+	 */
+	private Config $config;
+
+	/**
+	 * Buckets injected by the rules engine before hash generation.
+	 *
+	 * @var array<string, string>
+	 */
+	private array $extra_buckets = array();
+
+	/**
+	 * Memoized resolution result.
+	 *
+	 * @var array<string, string>|null
+	 */
+	private ?array $resolved = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param Config $config Cache configuration.
+	 */
+	public function __construct( Config $config ) {
+		$this->config = $config;
+	}
+
+	/**
+	 * Register a bucket for the current request.
+	 *
+	 * Empty names or tokens are silently dropped.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $name  Bucket name (e.g. `device`, `tenant`, `ab`).
+	 * @param string $token Bucket token; folded into the request hash.
+	 * @return void
+	 */
+	public function add( string $name, string $token ): void {
+		if ( '' === $name || '' === $token ) {
+			return;
+		}
+		$this->extra_buckets[ $name ] = $token;
+		$this->resolved               = null;
+	}
+
+	/**
+	 * Get the full resolved bucket map.
+	 *
+	 * Runs built-in resolvers (Authorization always-on, Accept dormant
+	 * unless `MC_CACHE_BUCKETS['accept']` is configured), then merges any
+	 * buckets registered via {@see Resolver::add()}. Programmatic
+	 * additions take precedence when names collide. Memoized after first
+	 * call until {@see Resolver::add()} invalidates it.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return array<string, string> Bucket name → token map.
+	 */
+	public function all(): array {
+		if ( null !== $this->resolved ) {
+			return $this->resolved;
+		}
+
+		$buckets = array();
+
+		$auth = $this->resolve_authorization();
+		if ( null !== $auth ) {
+			$buckets['auth'] = $auth;
+		}
+
+		$accept = $this->resolve_accept();
+		if ( null !== $accept ) {
+			$buckets['accept'] = $accept;
+		}
+
+		foreach ( $this->extra_buckets as $name => $token ) {
+			$buckets[ $name ] = $token;
+		}
+
+		$this->resolved = $buckets;
+		return $buckets;
+	}
+
+	/**
+	 * Get the resolved token for a single bucket.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $name Bucket name (e.g. `accept`, `auth`).
+	 * @return string|null Token, or null when the bucket did not resolve.
+	 */
+	public function get( string $name ): ?string {
+		return $this->all()[ $name ] ?? null;
+	}
+
+	/**
+	 * Resolve the Authorization-header bucket.
+	 *
+	 * Each unique Authorization header maps to a per-value bucket so
+	 * authenticated requests don't share cache entries with each other or
+	 * with anonymous requests.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return string|null Per-token bucket value, or null when absent.
+	 */
+	private function resolve_authorization(): ?string {
+		$auth = ServerVars::get( 'HTTP_AUTHORIZATION' );
+		if ( empty( $auth ) ) {
+			return null;
+		}
+
+		return md5( (string) $auth );
+	}
+
+	/**
+	 * Resolve the Accept-header bucket.
+	 *
+	 * Parses the request's Accept header (with q-values), takes the
+	 * top-preferred MIME type, and looks it up in the configured `accept`
+	 * bucket map. Returns null when no map is configured, when the header
+	 * is empty/wildcard, or when the top type isn't in the map.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return string|null Bucket token, or null when no match.
+	 */
+	private function resolve_accept(): ?string {
+		$accept_buckets = $this->config->buckets['accept'] ?? array();
+		if ( empty( $accept_buckets ) ) {
+			return null;
+		}
+
+		$accept = strtolower( trim( (string) ServerVars::get( 'HTTP_ACCEPT' ) ) );
+		if ( '' === $accept || '*/*' === $accept ) {
+			return null;
+		}
+
+		$top_type = $this->parse_accept_top_type( $accept );
+		if ( null === $top_type ) {
+			return null;
+		}
+
+		return $accept_buckets[ $top_type ] ?? null;
+	}
+
+	/**
+	 * Parse an Accept header and return the most-preferred MIME type.
+	 *
+	 * Honors q-values (defaulting to 1.0 when omitted). Ties resolve in
+	 * source order, matching RFC 9110 §12.5.1.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $accept Lowercased, trimmed Accept header value.
+	 * @return string|null The top-preferred MIME type, or null when none usable.
+	 */
+	private function parse_accept_top_type( string $accept ): ?string {
+		$entries = array();
+		foreach ( explode( ',', $accept ) as $position => $segment ) {
+			$segment = trim( $segment );
+			if ( '' === $segment ) {
+				continue;
+			}
+
+			$parts = explode( ';', $segment );
+			$type  = trim( (string) array_shift( $parts ) );
+			if ( '' === $type ) {
+				continue;
+			}
+
+			$q = 1.0;
+			foreach ( $parts as $param ) {
+				$param = trim( $param );
+				if ( 'q=' === substr( $param, 0, 2 ) ) {
+					$candidate = (float) substr( $param, 2 );
+					if ( $candidate >= 0.0 && $candidate <= 1.0 ) {
+						$q = $candidate;
+					}
+				}
+			}
+
+			$entries[] = array(
+				'type'     => $type,
+				'q'        => $q,
+				'position' => $position,
+			);
+		}
+
+		if ( empty( $entries ) ) {
+			return null;
+		}
+
+		usort(
+			$entries,
+			static function ( array $a, array $b ): int {
+				if ( $a['q'] !== $b['q'] ) {
+					return $b['q'] <=> $a['q'];
+				}
+				return $a['position'] <=> $b['position'];
+			}
+		);
+
+		return $entries[0]['type'];
+	}
+}

--- a/src/Engine/Request/Hasher.php
+++ b/src/Engine/Request/Hasher.php
@@ -13,15 +13,16 @@
 namespace MilliCache\Engine\Request;
 
 use MilliCache\Engine\Cache\Config;
+use MilliCache\Engine\Request\Bucket\Resolver as Buckets;
 use MilliCache\Engine\Utilities\ServerVars;
 
 ! defined( 'ABSPATH' ) && exit;
 
 /**
- * Generates unique hash for each request.
+ * Generates a unique hash for each request.
  *
  * Creates an MD5 hash based on request URI, host, method, cookies,
- * unique variables, and authorization headers to uniquely identify
+ * unique variables, and resolved request buckets to uniquely identify
  * cache entries.
  *
  * @since       1.0.0
@@ -44,6 +45,13 @@ final class Hasher {
 	 * @var Parser
 	 */
 	private Parser $parser;
+
+	/**
+	 * Bucket resolver.
+	 *
+	 * @var Buckets
+	 */
+	private Buckets $buckets;
 
 	/**
 	 * Generated request hash.
@@ -71,12 +79,14 @@ final class Hasher {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param Config $config Cache configuration.
-	 * @param Parser $parser Request parser.
+	 * @param Config       $config  Cache configuration.
+	 * @param Parser       $parser  Request parser.
+	 * @param Buckets|null $buckets Optional bucket resolver (defaults to a new instance).
 	 */
-	public function __construct( Config $config, Parser $parser ) {
-		$this->config = $config;
-		$this->parser = $parser;
+	public function __construct( Config $config, Parser $parser, ?Buckets $buckets = null ) {
+		$this->config  = $config;
+		$this->parser  = $parser;
+		$this->buckets = $buckets ?? new Buckets( $config );
 	}
 
 	/**
@@ -98,10 +108,10 @@ final class Hasher {
 			'cookies' => $this->parser->parse_cookies( $_COOKIE ),
 		);
 
-		// Make sure requests with Authorization headers are unique.
-		$auth = ServerVars::get( 'HTTP_AUTHORIZATION' );
-		if ( ! empty( $auth ) ) {
-			$request_hash['unique']['mc-auth-header'] = md5( $auth );
+		// Resolve request buckets.
+		$buckets = $this->buckets->all();
+		if ( ! empty( $buckets ) ) {
+			$request_hash['buckets'] = $buckets;
 		}
 
 		// Build variant dimensions (only non-default parts that differentiate this request).
@@ -117,6 +127,9 @@ final class Hasher {
 		}
 		if ( ! empty( $request_hash['unique'] ) ) {
 			$variant['unique'] = $request_hash['unique'];
+		}
+		if ( ! empty( $buckets ) ) {
+			$variant['buckets'] = $buckets;
 		}
 		$this->variant = ! empty( $variant ) ? $variant : null;
 
@@ -144,9 +157,9 @@ final class Hasher {
 	/**
 	 * Get variant dimensions from hash generation.
 	 *
-	 * Returns the non-default request dimensions (cookie names, unique variables)
-	 * that differentiate this cache entry from a vanilla anonymous request.
-	 * Null when the request has no variant dimensions.
+	 * Returns the non-default request dimensions (cookie names, unique
+	 * variables, resolved buckets) that differentiate this cache entry from
+	 * a vanilla anonymous request. Null when none applies.
 	 *
 	 * @since 1.4.0
 	 *

--- a/src/Engine/Request/Processor.php
+++ b/src/Engine/Request/Processor.php
@@ -13,6 +13,7 @@
 namespace MilliCache\Engine\Request;
 
 use MilliCache\Engine\Cache\Config;
+use MilliCache\Engine\Request\Bucket\Resolver as BucketResolver;
 use MilliCache\Engine\Utilities\ServerVars;
 
 ! defined( 'ABSPATH' ) && exit;
@@ -57,6 +58,13 @@ final class Processor {
 	 * @var Hasher|null
 	 */
 	private ?Hasher $hasher = null;
+
+	/**
+	 * Bucket resolver.
+	 *
+	 * @var BucketResolver|null
+	 */
+	private ?BucketResolver $buckets = null;
 
 	/**
 	 * Constructor.
@@ -106,9 +114,26 @@ final class Processor {
 	 */
 	public function get_hasher(): Hasher {
 		if ( ! $this->hasher ) {
-			$this->hasher = new Hasher( $this->config, $this->get_parser() );
+			$this->hasher = new Hasher( $this->config, $this->get_parser(), $this->buckets() );
 		}
 		return $this->hasher;
+	}
+
+	/**
+	 * Get the bucket resolver.
+	 *
+	 * Used by rule actions and other early-phase code to register additional
+	 * buckets via {@see BucketResolver::add_bucket()} before the hash is generated.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return BucketResolver The resolver instance.
+	 */
+	public function buckets(): BucketResolver {
+		if ( ! $this->buckets ) {
+			$this->buckets = new BucketResolver( $this->config );
+		}
+		return $this->buckets;
 	}
 
 	/**

--- a/src/Engine/Response/Processor.php
+++ b/src/Engine/Response/Processor.php
@@ -142,14 +142,26 @@ final class Processor {
 		$custom_ttl   = $this->state->get_ttl_override();
 		$custom_grace = $this->state->get_grace_override();
 		$variant      = $this->request_manager->get_variant();
+		$headers      = headers_list();
 
-		// Cache the output.
+		// Bypass storage entirely for unsupported Vary directives.
+		$vary_bypass = $this->should_bypass_for_vary( $headers );
+		if ( null !== $vary_bypass ) {
+			if ( ! $this->state->should_fcgi_regenerate() ) {
+				$this->headers->set_status( 'bypass' );
+			}
+			$this->headers->set_reason( $vary_bypass );
+			return $this->state->should_fcgi_regenerate() ? null : $output;
+		}
+
+		// Store the response. Identical bodies across variants are deduplicated
+		// automatically by the Storage layer's content-addressable output keyspace.
 		$result = $this->cache_manager->cache_output(
-			$this->state->get_request_hash(),
+			$this->request_manager->get_hasher()->get_hash() ?? '',
 			$output,
 			$flags,
 			$status,
-			headers_list(),
+			$headers,
 			$custom_ttl,
 			$custom_grace,
 			$url,
@@ -168,6 +180,86 @@ final class Processor {
 
 		// Return output (null for background FCGI tasks).
 		return $this->state->should_fcgi_regenerate() ? null : $output;
+	}
+
+	/**
+	 * Decide whether to bypass storage entirely based on Vary directives.
+	 *
+	 * Vary: *, Vary: Cookie, and Vary on any header outside the supported
+	 * allowlist (Accept, Accept-Encoding) make a response unsafe to cache
+	 * without a richer keying mechanism. Returns a human-readable bypass
+	 * reason when storage should be skipped, or null to proceed.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param array<string> $headers Response headers ("Key: Value" strings).
+	 * @return string|null Bypass reason, or null to allow caching.
+	 */
+	private function should_bypass_for_vary( array $headers ): ?string {
+		$vary = $this->extract_header_value( $headers, 'vary' );
+		if ( '' === $vary ) {
+			return null;
+		}
+
+		$tokens = $this->parse_vary( $vary );
+
+		if ( in_array( '*', $tokens, true ) ) {
+			return 'Vary: * is uncacheable';
+		}
+
+		$allowed = array( 'accept', 'accept-encoding' );
+		foreach ( $tokens as $token ) {
+			if ( ! in_array( $token, $allowed, true ) ) {
+				return 'Vary: ' . $token . ' is not supported';
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Extract a single header value from a "Key: Value" header list.
+	 *
+	 * Returns the trimmed value of the last occurrence of the named header
+	 * (matching is case-insensitive). Returns an empty string when missing.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param array<string> $headers Header lines.
+	 * @param string        $name    Lowercase header name.
+	 * @return string Header value, or empty string.
+	 */
+	private function extract_header_value( array $headers, string $name ): string {
+		$value = '';
+		foreach ( $headers as $header ) {
+			if ( ! is_string( $header ) || false === strpos( $header, ':' ) ) {
+				continue;
+			}
+			list( $key, $candidate ) = explode( ':', $header, 2 );
+			if ( strtolower( trim( $key ) ) === $name ) {
+				$value = trim( $candidate );
+			}
+		}
+		return $value;
+	}
+
+	/**
+	 * Parse a Vary header value into a list of lowercased, deduplicated tokens.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param string $vary Vary header value.
+	 * @return array<string> Tokens.
+	 */
+	private function parse_vary( string $vary ): array {
+		$tokens = array();
+		foreach ( explode( ',', $vary ) as $token ) {
+			$token = strtolower( trim( $token ) );
+			if ( '' !== $token ) {
+				$tokens[] = $token;
+			}
+		}
+		return array_values( array_unique( $tokens ) );
 	}
 
 	/**
@@ -249,20 +341,28 @@ final class Processor {
 		?int $custom_ttl = null,
 		?int $custom_grace = null
 	): array {
-		$hash = $this->request_manager->get_hasher()->get_hash();
-		if ( ! $hash ) {
-			$hash = $this->request_manager->process();
+		if ( ! $this->request_manager->get_hasher()->get_hash() ) {
+			$this->request_manager->process();
+		}
+
+		$vary_bypass = $this->should_bypass_for_vary( $headers );
+		if ( null !== $vary_bypass ) {
+			return array(
+				'cached' => false,
+				'reason' => $vary_bypass,
+			);
 		}
 
 		return $this->cache_manager->cache_output(
-			$hash,
+			$this->request_manager->get_hasher()->get_hash() ?? '',
 			$output,
 			$this->collect_flags(),
 			$status,
 			$headers,
 			$custom_ttl,
 			$custom_grace,
-			$this->request_manager->get_url() ?? ''
+			$this->request_manager->get_url() ?? '',
+			$this->request_manager->get_variant()
 		);
 	}
 

--- a/src/Rules/Actions/PHP/SetBucket.php
+++ b/src/Rules/Actions/PHP/SetBucket.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Set Bucket Action
+ *
+ * Adds a bucket to the request hash for the current request.
+ *
+ * @link        https://www.millipress.com
+ * @since       1.7.0
+ *
+ * @package     MilliCache
+ * @subpackage  Rules\Actions\PHP
+ * @author      Philipp Wellmer <hello@millipress.com>
+ */
+
+namespace MilliCache\Rules\Actions\PHP;
+
+use MilliRules\Actions\ActionMeta;
+use MilliRules\Actions\BaseAction;
+use MilliRules\Context;
+
+/**
+ * Class SetBucket
+ *
+ * Registers a bucket (name + token) on the request resolver. The bucket
+ * folds into the request hash so that variants sharing the same bucket
+ * map to the same cache entry.
+ *
+ * @since 1.7.0
+ */
+class SetBucket extends BaseAction {
+
+	/**
+	 * Highest rule order seen per bucket name.
+	 *
+	 * Higher-order rules win, mirroring the SetGrace/SetTtl pattern.
+	 * Tracked per-name so unrelated buckets don't suppress each other.
+	 *
+	 * @since 1.7.0
+	 * @var array<string, int>
+	 */
+	private static array $last_orders = array();
+
+	/**
+	 * Declare metadata for the set_bucket action.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param ActionMeta $meta The metadata object to configure.
+	 * @return void
+	 */
+	public static function set_meta( ActionMeta $meta ): void {
+		$meta
+			->label( __( 'Set Bucket', 'millicache' ) )
+			->description( __( 'Add a bucket (name + token) to the request hash so matching requests share a cache entry.', 'millicache' ) )
+			->categories( 'caching' )
+			->args()
+				->string( 'name' )
+					->label( __( 'Bucket Name', 'millicache' ) )
+					->description( __( 'Identifier for the bucket dimension (e.g. device, tenant, ab).', 'millicache' ) )
+					->default( '' )
+				->string( 'token' )
+					->label( __( 'Token', 'millicache' ) )
+					->description( __( 'Short canonical value folded into the request hash.', 'millicache' ) )
+					->default( '' );
+	}
+
+	/**
+	 * Get the action type.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return string The action type identifier.
+	 */
+	public function get_type(): string {
+		return 'set_bucket';
+	}
+
+	/**
+	 * Execute the action.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param Context $context The execution context.
+	 * @return void
+	 */
+	public function execute( Context $context ): void {
+		$name  = $this->get_arg( 0 )->string();
+		$token = $this->get_arg( 1 )->string();
+
+		if ( '' === $name || '' === $token ) {
+			return;
+		}
+
+		$order = $context->get( 'rule.order' );
+		$order = is_int( $order ) ? $order : 10;
+
+		// Skip if a higher-order rule already set this bucket.
+		if ( isset( self::$last_orders[ $name ] ) && $order < self::$last_orders[ $name ] ) {
+			return;
+		}
+		self::$last_orders[ $name ] = $order;
+
+		millicache()
+			->request()
+			->buckets()
+			->add( $name, $token );
+	}
+}

--- a/tests/Unit/Engine/Cache/ConfigTest.php
+++ b/tests/Unit/Engine/Cache/ConfigTest.php
@@ -90,4 +90,61 @@ describe( 'CacheConfig', function () {
 			expect( $config->gzip )->toBeTrue(); // Default.
 		} );
 	} );
+
+	describe( 'buckets', function () {
+
+		it( 'defaults to an empty map when settings omit the field', function () {
+			$config = Config::from_settings( array() );
+
+			expect( $config->buckets )->toBe( array() );
+		} );
+
+		it( 'reads nested buckets from settings and lowercases keys', function () {
+			$config = Config::from_settings( array(
+				'buckets' => array(
+					'Accept' => array(
+						'Text/Markdown'         => 'md',
+						' application/ld+json ' => 'jsonld',
+					),
+				),
+			) );
+
+			expect( $config->buckets )->toBe( array(
+				'accept' => array(
+					'text/markdown'       => 'md',
+					'application/ld+json' => 'jsonld',
+				),
+			) );
+		} );
+
+		it( 'drops invalid pairs without breaking the rest of the map', function () {
+			$config = Config::from_settings( array(
+				'buckets' => array(
+					'accept' => array(
+						'text/markdown' => 'md',
+						'text/plain'    => '',     // empty token, dropped.
+						123             => 'bad',  // non-string key, dropped.
+					),
+				),
+			) );
+
+			expect( $config->buckets )->toBe( array(
+				'accept' => array( 'text/markdown' => 'md' ),
+			) );
+		} );
+
+		it( 'supports multiple bucket dimensions side by side', function () {
+			$config = Config::from_settings( array(
+				'buckets' => array(
+					'accept'   => array( 'text/markdown' => 'md' ),
+					'language' => array( 'de' => 'de', 'fr' => 'fr' ),
+				),
+			) );
+
+			expect( $config->buckets )->toBe( array(
+				'accept'   => array( 'text/markdown' => 'md' ),
+				'language' => array( 'de' => 'de', 'fr' => 'fr' ),
+			) );
+		} );
+	} );
 } );

--- a/tests/Unit/Engine/Cache/EntryTest.php
+++ b/tests/Unit/Engine/Cache/EntryTest.php
@@ -176,4 +176,5 @@ describe( 'CacheEntry', function () {
 			expect( $converted_back )->toBe( $original_data );
 		} );
 	} );
+
 } );

--- a/tests/Unit/Engine/Request/HasherTest.php
+++ b/tests/Unit/Engine/Request/HasherTest.php
@@ -231,14 +231,150 @@ describe('Hasher', function () {
 			expect($variant['unique'])->toBe(array( 'device', 'mobile' ));
 		});
 
-		it('includes auth header in unique when present', function () {
+		it('exposes auth header as an "auth" bucket when present', function () {
 			$_COOKIE = array();
 			$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer token123';
 			$this->hasher->generate();
 
 			$variant = $this->hasher->get_variant();
 			expect($variant)->not->toBeNull();
-			expect($variant['unique'])->toHaveKey('mc-auth-header');
+			expect($variant)->toHaveKey('buckets');
+			expect($variant['buckets'])->toHaveKey('auth');
+			expect($variant['buckets']['auth'])->toBe(md5('Bearer token123'));
+		});
+	});
+
+	describe('Accept negotiation bucket', function () {
+		beforeEach(function () {
+			$this->bucket_config   = new Config(
+				3600, 600, true, false,
+				array(), array(), array(), array(), array(),
+				array( 'accept' => array( 'text/markdown' => 'md' ) )
+			);
+			$this->bucket_parser   = new Parser($this->bucket_config);
+			$this->bucket_resolver = new \MilliCache\Engine\Request\Bucket\Resolver($this->bucket_config);
+			$this->bucket_hasher   = new Hasher($this->bucket_config, $this->bucket_parser, $this->bucket_resolver);
+		});
+
+		it('returns null bucket when no Accept header is sent', function () {
+			unset($_SERVER['HTTP_ACCEPT']);
+			$this->bucket_hasher->generate();
+
+			expect($this->bucket_resolver->get('accept'))->toBeNull();
+		});
+
+		it('returns null bucket for wildcard Accept', function () {
+			$_SERVER['HTTP_ACCEPT'] = '*/*';
+			$this->bucket_hasher->generate();
+
+			expect($this->bucket_resolver->get('accept'))->toBeNull();
+		});
+
+		it('returns md bucket when text/markdown is the top preference', function () {
+			$_SERVER['HTTP_ACCEPT'] = 'text/markdown';
+			$this->bucket_hasher->generate();
+
+			expect($this->bucket_resolver->get('accept'))->toBe('md');
+		});
+
+		it('routes a typical browser Accept to the default bucket', function () {
+			$_SERVER['HTTP_ACCEPT'] = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8';
+			$this->bucket_hasher->generate();
+
+			expect($this->bucket_resolver->get('accept'))->toBeNull();
+		});
+
+		it('honors q-value preference (md preferred wins)', function () {
+			$_SERVER['HTTP_ACCEPT'] = 'text/html;q=0.5, text/markdown;q=1.0';
+			$this->bucket_hasher->generate();
+
+			expect($this->bucket_resolver->get('accept'))->toBe('md');
+		});
+
+		it('produces different hashes for default and md buckets', function () {
+			$_SERVER['HTTP_ACCEPT'] = 'text/html';
+			$this->bucket_hasher->generate();
+			$default_hash = $this->bucket_hasher->get_hash();
+
+			$_SERVER['HTTP_ACCEPT'] = 'text/markdown';
+			$md_resolver = new \MilliCache\Engine\Request\Bucket\Resolver($this->bucket_config);
+			$md_hasher   = new Hasher($this->bucket_config, $this->bucket_parser, $md_resolver);
+			$md_hasher->generate();
+
+			expect($md_hasher->get_hash())->not->toBe($default_hash);
+		});
+
+		it('surfaces the bucket in the variant for debug headers', function () {
+			$_COOKIE = array();
+			$_SERVER['HTTP_ACCEPT'] = 'text/markdown';
+			$this->bucket_hasher->generate();
+
+			$variant = $this->bucket_hasher->get_variant();
+
+			expect($variant)->not->toBeNull();
+			expect($variant['buckets']['accept'])->toBe('md');
+		});
+
+		it('does not bucket when no accept map is configured', function () {
+			$bare_config   = create_test_config();
+			$bare_resolver = new \MilliCache\Engine\Request\Bucket\Resolver($bare_config);
+			$bare_hasher   = new Hasher($bare_config, new Parser($bare_config), $bare_resolver);
+			$_SERVER['HTTP_ACCEPT'] = 'text/markdown';
+			$bare_hasher->generate();
+
+			expect($bare_resolver->get('accept'))->toBeNull();
+		});
+	});
+
+	describe('Resolver::add programmatic extension', function () {
+		it('merges programmatically added buckets into the resolved set', function () {
+			$resolver = new \MilliCache\Engine\Request\Bucket\Resolver($this->config);
+			$resolver->add('language', 'en');
+			$resolver->add('tenant', 'acme');
+
+			$hasher = new Hasher($this->config, $this->parser, $resolver);
+			$hasher->generate();
+
+			expect($resolver->get('language'))->toBe('en');
+			expect($resolver->get('tenant'))->toBe('acme');
+		});
+
+		it('silently drops empty names and tokens', function () {
+			$resolver = new \MilliCache\Engine\Request\Bucket\Resolver($this->config);
+			$resolver->add('good', 'ok');
+			$resolver->add('', 'no-name');
+			$resolver->add('no-token', '');
+
+			$hasher = new Hasher($this->config, $this->parser, $resolver);
+			$hasher->generate();
+
+			expect($resolver->all())->toBe(array( 'good' => 'ok' ));
+		});
+
+		it('a programmatically added bucket changes the hash', function () {
+			$base_hasher = new Hasher($this->config, $this->parser);
+			$base_hasher->generate();
+			$base_hash = $base_hasher->get_hash();
+
+			$resolver = new \MilliCache\Engine\Request\Bucket\Resolver($this->config);
+			$resolver->add('tenant', 'acme');
+
+			$tenant_hasher = new Hasher($this->config, $this->parser, $resolver);
+			$tenant_hasher->generate();
+
+			expect($tenant_hasher->get_hash())->not->toBe($base_hash);
+		});
+
+		it('overrides built-in resolver output when names collide', function () {
+			$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer real-token';
+
+			$resolver = new \MilliCache\Engine\Request\Bucket\Resolver($this->config);
+			$resolver->add('auth', 'forced');
+
+			$hasher = new Hasher($this->config, $this->parser, $resolver);
+			$hasher->generate();
+
+			expect($resolver->get('auth'))->toBe('forced');
 		});
 	});
 });

--- a/tests/Unit/Rules/ActionsTest.php
+++ b/tests/Unit/Rules/ActionsTest.php
@@ -11,6 +11,7 @@
 use MilliCache\Rules\Actions\PHP\DoCache;
 use MilliCache\Rules\Actions\PHP\SetTtl;
 use MilliCache\Rules\Actions\PHP\SetGrace;
+use MilliCache\Rules\Actions\PHP\SetBucket;
 use MilliCache\Rules\Actions\WP\AddFlag;
 use MilliCache\Rules\Actions\WP\RemoveFlag;
 use MilliCache\Rules\Actions\WP\ClearCache;
@@ -97,6 +98,31 @@ describe( 'Rule Actions', function () {
 			$context = Mockery::mock( Context::class );
 			$action  = new SetGrace( array( 'type' => 'set_grace' ), $context );
 			expect( $action->get_type() )->toBe( 'set_grace' );
+		} );
+	} );
+
+	describe( 'SetBucket Action', function () {
+		it( 'class exists', function () {
+			expect( class_exists( SetBucket::class ) )->toBeTrue();
+		} );
+
+		it( 'extends BaseAction', function () {
+			$reflection = new ReflectionClass( SetBucket::class );
+			expect( $reflection->isSubclassOf( 'MilliRules\Actions\BaseAction' ) )->toBeTrue();
+		} );
+
+		it( 'has get_type method', function () {
+			expect( method_exists( SetBucket::class, 'get_type' ) )->toBeTrue();
+		} );
+
+		it( 'has execute method', function () {
+			expect( method_exists( SetBucket::class, 'execute' ) )->toBeTrue();
+		} );
+
+		it( 'returns correct action type', function () {
+			$context = Mockery::mock( Context::class );
+			$action  = new SetBucket( array( 'type' => 'set_bucket' ), $context );
+			expect( $action->get_type() )->toBe( 'set_bucket' );
 		} );
 	} );
 
@@ -284,12 +310,21 @@ describe( 'Rule Actions', function () {
 			expect( Rules::get_action_meta( 'set_ttl' )->get_scope() )->toBe( '' );
 			expect( Rules::get_action_meta( 'set_grace' )->get_scope() )->toBe( '' );
 			expect( Rules::get_action_meta( 'do_cache' )->get_scope() )->toBe( '' );
+			expect( Rules::get_action_meta( 'set_bucket' )->get_scope() )->toBe( '' );
 		} );
 
 		it( 'exposes caching actions under the caching category', function () {
 			expect( Rules::get_action_meta( 'set_ttl' )->get_categories() )->toContain( 'caching' );
 			expect( Rules::get_action_meta( 'set_grace' )->get_categories() )->toContain( 'caching' );
 			expect( Rules::get_action_meta( 'do_cache' )->get_categories() )->toContain( 'caching' );
+			expect( Rules::get_action_meta( 'set_bucket' )->get_categories() )->toContain( 'caching' );
+		} );
+
+		it( 'declares set_bucket arguments (name, token)', function () {
+			$args = Rules::get_action_meta( 'set_bucket' )->get_arguments();
+			expect( $args )->toHaveCount( 2 );
+			expect( $args[0]->get_type() )->toBe( 'string' );
+			expect( $args[1]->get_type() )->toBe( 'string' );
 		} );
 
 		it( 'stores the action type string (not the class name) on ActionMeta', function () {
@@ -350,6 +385,7 @@ describe( 'Rule Actions', function () {
 			expect( is_subclass_of( DoCache::class, 'MilliRules\Actions\BaseAction' ) )->toBeTrue();
 			expect( is_subclass_of( SetTtl::class, 'MilliRules\Actions\BaseAction' ) )->toBeTrue();
 			expect( is_subclass_of( SetGrace::class, 'MilliRules\Actions\BaseAction' ) )->toBeTrue();
+			expect( is_subclass_of( SetBucket::class, 'MilliRules\Actions\BaseAction' ) )->toBeTrue();
 		} );
 
 		it( 'all WP actions extend BaseAction', function () {
@@ -365,6 +401,7 @@ describe( 'Rule Actions', function () {
 				( new DoCache( array( 'type' => 'do_cache' ), $context ) )->get_type(),
 				( new SetTtl( array( 'type' => 'set_ttl' ), $context ) )->get_type(),
 				( new SetGrace( array( 'type' => 'set_grace' ), $context ) )->get_type(),
+				( new SetBucket( array( 'type' => 'set_bucket' ), $context ) )->get_type(),
 				( new AddFlag( array( 'type' => 'add_flag' ), $context ) )->get_type(),
 				( new RemoveFlag( array( 'type' => 'remove_flag' ), $context ) )->get_type(),
 				( new ClearCache( array( 'type' => 'clear_cache' ), $context ) )->get_type(),


### PR DESCRIPTION
## Summary

Adds a per-request bucket framework that any dimension (auth token, content type, A/B arm, tenant, …) can plug into via `Resolver::add()`. Replaces the alias mechanism with a content-addressable output keyspace plus refs SET for refcount-based GC. Identical bodies across variants now share storage automatically.

## What's new

- **Bucket framework** — built-in `auth` resolver (always-on, security primitive) and `accept` resolver (dormant unless `MC_CACHE_BUCKETS['accept']` is configured)
- **`set_bucket` rule action** — site admins can differentiate cache by any request signal expressible as a rule condition
- **Output keyspace dedup** — bodies stored at `<prefix>:o:<sha1>` and shared across variants whose rendered output is byte-identical; refcount-based cleanup via Redis SET

## Test plan

- [x] `vendor/bin/pest` — 777 tests, 1439 assertions, all passing
- [x] `vendor/bin/phpstan analyse` — max level, 0 errors
- [x] Live verification on `wp.test`: cookie-driven A/B variants share one body via dedup
- [x] Live verification on `millipress.test`: Accept-driven HTML/markdown variants get distinct bodies, both invalidated together via shared flags

See commit `37253eaa4` for full implementation details.