### PR TITLE
ci(release-please): use millipress-bot App token instead of RELEASE_TOKEN

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,16 +20,23 @@ jobs:
       sha: ${{ steps.release.outputs.sha }}
 
     steps:
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MILLIPRESS_BOT_APP_ID }}
+          private-key: ${{ secrets.MILLIPRESS_BOT_PRIVATE_KEY }}
+
       - name: Run Release Please
         id: release
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Convert release to draft
         if: ${{ steps.release.outputs.release_created }}
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
         run: gh release edit "$TAG_NAME" --draft --repo "${{ github.repository }}"
 


### PR DESCRIPTION
## Summary
- Mints a per-run installation token from the millipress-bot GitHub App in `release-please.yml` and uses it for both the `release-please-action` step and the `gh release edit --draft` step.
- Removes the dependency on `secrets.RELEASE_TOKEN` (a PAT) for these two steps.
- Preserves the existing downstream-workflow-trigger behavior (App tokens and PATs both bypass the `GITHUB_TOKEN` no-trigger rule; the default `GITHUB_TOKEN` would not).

## Why
- `RELEASE_TOKEN` is a PAT — expires silently, tied to a personal account, account-scoped (wide blast radius).
- The millipress-bot App is already used in `ci.yml` for the asset-rebuild push. Reusing it here removes one more secret to rotate and keeps release authorship attributed to `millipress-bot[bot]`.

## Preconditions to verify before merging
- [x] millipress-bot App installation on `MilliCache` has **Repository permissions → Contents: Read & write** AND **Pull requests: Read & write** (release-please needs both).
- [x] `MILLIPRESS_BOT_APP_ID` and `MILLIPRESS_BOT_PRIVATE_KEY` are present (already used by `ci.yml`, so this should be fine).
- [x] If `main` has branch protection requiring signed commits or specific reviewers, confirm `millipress-bot[bot]` can satisfy them — same path the human owner of `RELEASE_TOKEN` takes today.

## Test plan
- [ ] Merge and let the next release-please cycle run end-to-end (PR creation, merge, draft creation, draft promotion).
- [ ] Confirm release-please's PR and the resulting tag/release are attributed to `millipress-bot[bot]`.
- [ ] Confirm the post-release tag push triggers downstream workflows as before.
- [ ] After one successful release cycle: revoke `secrets.RELEASE_TOKEN` from repo settings.

## Notes
- A separate, follow-up change adds a `repository_dispatch` to MilliCache-Pro on release publish — that lands on the `next` branch and is unrelated to this token migration.
- Dependabot PR #124 bumps `actions/create-github-app-token` from v1 to v3 in `ci.yml`. This PR pins to `@v3` directly for the new step; once #124 merges, both files will be aligned.