### PR TITLE
ci(next): use millipress-bot App token instead of RELEASE_TOKEN

### DIFF
--- a/.github/workflows/polish-release-pr.yml
+++ b/.github/workflows/polish-release-pr.yml
@@ -15,10 +15,12 @@ name: Polish Release PR (next)
 # Skipped silently when the label isn't present (e.g. regular PRs).
 #
 # Required repository secrets:
-#   LLM_PROXY_URL  - Proxy API root, including /v1  (e.g. https://llm-api.example.com/v1)
-#   LLM_PROXY_KEY  - Bearer token your proxy accepts
-#   RELEASE_TOKEN  - PAT with contents:write + pull-requests:write
-#                    (same secret release-please-next.yml uses)
+#   LLM_PROXY_URL              - Proxy API root, including /v1  (e.g. https://llm-api.example.com/v1)
+#   LLM_PROXY_KEY              - Bearer token your proxy accepts
+#   MILLIPRESS_BOT_APP_ID      - millipress-bot GitHub App ID
+#   MILLIPRESS_BOT_PRIVATE_KEY - millipress-bot GitHub App private key
+#                                (App needs Contents: write + Pull requests: write;
+#                                same App release-please-next.yml uses)
 #
 # Change LLM_MODEL below to swap the backing model. Any model name your proxy
 # routes will work (claude-sonnet-4-6, claude-opus-4-7, gpt-4o, etc.).
@@ -43,15 +45,22 @@ jobs:
       LLM_MODEL: claude-sonnet-4-6
 
     steps:
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MILLIPRESS_BOT_APP_ID }}
+          private-key: ${{ secrets.MILLIPRESS_BOT_PRIVATE_KEY }}
+
       - name: Checkout default
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Switch to release PR branch
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: gh pr checkout "$PR_NUMBER"
 

--- a/.github/workflows/polish-release-pr.yml
+++ b/.github/workflows/polish-release-pr.yml
@@ -1,29 +1,6 @@
 name: Polish Release PR (next)
 
-# When release-please opens or updates the release PR on the `next` branch,
-# this workflow asks an LLM (via your CLI Proxy API) to add a friendly,
-# user-facing prose introduction to the newest changelog entry. The
-# original auto-generated bullet list is preserved verbatim under the
-# intro. Older entries are never touched.
-#
-# The polished changelog is what release-please reads when it creates the
-# GitHub Release at merge time, so the prose intro becomes part of the
-# permanent release notes. The PR description itself is left as
-# release-please's auto-generated version (we don't fight it on every run).
-#
-# Triggered only on PRs that release-please labelled with `autorelease: pending`.
-# Skipped silently when the label isn't present (e.g. regular PRs).
-#
-# Required repository secrets:
-#   LLM_PROXY_URL              - Proxy API root, including /v1  (e.g. https://llm-api.example.com/v1)
-#   LLM_PROXY_KEY              - Bearer token your proxy accepts
-#   MILLIPRESS_BOT_APP_ID      - millipress-bot GitHub App ID
-#   MILLIPRESS_BOT_PRIVATE_KEY - millipress-bot GitHub App private key
-#                                (App needs Contents: write + Pull requests: write;
-#                                same App release-please-next.yml uses)
-#
-# Change LLM_MODEL below to swap the backing model. Any model name your proxy
-# routes will work (claude-sonnet-4-6, claude-opus-4-7, gpt-4o, etc.).
+# Adds a prose intro to the newest changelog entry on release PRs.
 
 on:
   pull_request:

--- a/.github/workflows/polish-release-pr.yml
+++ b/.github/workflows/polish-release-pr.yml
@@ -1,8 +1,15 @@
 name: Polish Release PR (next)
 
 # When release-please opens or updates the release PR on the `next` branch,
-# this workflow asks an LLM (via your CLI Proxy API) to rewrite the
-# auto-generated changelog entry and the PR body in user-facing language.
+# this workflow asks an LLM (via your CLI Proxy API) to add a friendly,
+# user-facing prose introduction to the newest changelog entry. The
+# original auto-generated bullet list is preserved verbatim under the
+# intro. Older entries are never touched.
+#
+# The polished changelog is what release-please reads when it creates the
+# GitHub Release at merge time, so the prose intro becomes part of the
+# permanent release notes. The PR description itself is left as
+# release-please's auto-generated version (we don't fight it on every run).
 #
 # Triggered only on PRs that release-please labelled with `autorelease: pending`.
 # Skipped silently when the label isn't present (e.g. regular PRs).
@@ -213,57 +220,6 @@ jobs:
             exit 1
           fi
 
-      - name: Generate PR body via LLM proxy
-        if: steps.guard.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          NEWEST=$(awk '/^## /{n++; if(n==2) exit} {print}' docs/01-getting-started/30-changelog.md)
-
-          SYSTEM_PROMPT=$(cat <<'EOF'
-          Write a pull-request description for a MilliCache release. The audience is the maintainer reviewing the release PR plus anyone reading the merged commit later (including non-engineers who want to know what this release changed for them).
-
-          Tone: friendly, plain English, no deep jargon. A bit of humor is fine where it fits naturally — don't force it. Use simple examples to illustrate user-visible changes when it helps.
-
-          Structure:
-          - One-sentence summary at the top, written for a regular WordPress user.
-          - Grouped highlights (Features, Fixes, Performance, Dependencies — only the sections that actually have content).
-          - Short "Testing" line referencing Pest unit tests, PHPStan max, and the e2e gate.
-          - Closing: link to the file docs/01-getting-started/30-changelog.md for the full entry.
-
-          STRICT ACCURACY RULES:
-          - Describe only what the changelog entry you receive actually claims. Do not invent UIs, admin features, CLI commands, or workflows. MilliCache free has no admin UI for rules — don't claim otherwise.
-          - Do not promise behaviour ("works automatically", "no setup required") unless the changelog entry says so.
-          - When unsure, omit. Brevity beats fabrication.
-
-          Output is the raw markdown body, no fences or wrappers.
-          EOF
-          )
-
-          PAYLOAD=$(jq -n \
-            --arg model   "$LLM_MODEL" \
-            --arg system  "$SYSTEM_PROMPT" \
-            --arg user    "$NEWEST" \
-            '{
-               model: $model,
-               temperature: 0.4,
-               messages: [
-                 { role: "system", content: $system },
-                 { role: "user",   content: ("Newest changelog entry:\n\n" + $user) }
-               ]
-             }')
-
-          curl -fsS "$LLM_PROXY_URL/chat/completions" \
-            -H "Authorization: Bearer $LLM_PROXY_KEY" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD" \
-            | jq -r '.choices[0].message.content' \
-            > /tmp/pr-body.md
-
-          if [ ! -s /tmp/pr-body.md ]; then
-            echo "::warning::PR body came back empty - leaving release-please's default in place."
-            rm -f /tmp/pr-body.md
-          fi
-
       - name: Commit + push polished changelog
         if: steps.guard.outputs.skip != 'true'
         run: |
@@ -274,11 +230,3 @@ jobs:
             git commit -m "docs(changelog): polish release notes"
             git push origin HEAD
           fi
-
-      - name: Update PR description
-        if: steps.guard.outputs.skip != 'true' && hashFiles('/tmp/pr-body.md') != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.md --repo "$REPO"

--- a/.github/workflows/release-please-next.yml
+++ b/.github/workflows/release-please-next.yml
@@ -19,11 +19,18 @@ jobs:
       version: ${{ steps.release.outputs.version }}
 
     steps:
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MILLIPRESS_BOT_APP_ID }}
+          private-key: ${{ secrets.MILLIPRESS_BOT_PRIVATE_KEY }}
+
       - name: Run Release Please
         id: release
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           target-branch: next
           config-file: release-please-config-next.json
           manifest-file: .release-please-manifest-next.json
@@ -31,7 +38,7 @@ jobs:
       - name: Mark release as prerelease + draft
         if: ${{ steps.release.outputs.release_created }}
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
           REPO: ${{ github.repository }}
         run: gh release edit "$TAG_NAME" --prerelease --draft --repo "$REPO"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,16 +20,23 @@ jobs:
       sha: ${{ steps.release.outputs.sha }}
 
     steps:
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MILLIPRESS_BOT_APP_ID }}
+          private-key: ${{ secrets.MILLIPRESS_BOT_PRIVATE_KEY }}
+
       - name: Run Release Please
         id: release
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Convert release to draft
         if: ${{ steps.release.outputs.release_created }}
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
         run: gh release edit "$TAG_NAME" --draft --repo "${{ github.repository }}"
 


### PR DESCRIPTION
## Summary
Migrates all three workflows on `next` that use `secrets.RELEASE_TOKEN` over to a per-run installation token from the millipress-bot GitHub App:

- `release-please.yml` — stable channel (push to `main`)
- `release-please-next.yml` — prerelease channel (push to `next`)
- `polish-release-pr.yml` — LLM-driven changelog rewrite on release PRs

Same downstream-trigger behavior as a PAT (unlike the default `GITHUB_TOKEN`), but auto-rotates, scoped per-install, and not tied to a personal account.

## Companion PR
Mirrors #127 (which migrates `release-please.yml` on `main`). Once both land and one release cycle on each channel succeeds, `secrets.RELEASE_TOKEN` can be revoked.

## Preconditions to verify before merging
- [ ] millipress-bot App installation on `MilliCache` has **Repository permissions → Contents: Read & write** AND **Pull requests: Read & write**.
- [ ] `MILLIPRESS_BOT_APP_ID` and `MILLIPRESS_BOT_PRIVATE_KEY` are present (already used by `ci.yml`).
- [ ] If `next` or `main` has branch protection requiring signed commits or specific reviewers, confirm `millipress-bot[bot]` can satisfy them.

## Test plan
- [ ] Merge and let the next release-please cycle run on both `main` and `next`.
- [ ] Confirm the release-please PR + tag + draft are attributed to `millipress-bot[bot]`.
- [ ] Confirm `polish-release-pr.yml` can still push the polished-changelog commit to the release PR branch (this is the trickiest one — it pushes back into a release-please PR branch).
- [ ] Confirm tag-push triggers downstream workflows (e.g. `Build & Release`) as before.
- [ ] After one successful cycle: revoke `secrets.RELEASE_TOKEN`.

## Notes
- Pinned new steps to `actions/create-github-app-token@v3`. Dependabot #124 will bring `ci.yml` to the same major.
- `polish-release-pr.yml`'s secrets-list comment was updated to document the App secrets in place of `RELEASE_TOKEN`.