### PR TITLE
ci: Run CI on PRs targeting next

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
       - 'package-lock.json'
       - 'webpack.config.js'
   pull_request:
-    branches: [main, dev]
+    branches: [main, next, dev]
     # No paths filter - always run CI on PRs to catch issues before merge
 
 permissions:


### PR DESCRIPTION
## Summary
- The `pull_request` trigger in `ci.yml` only listed `[main, dev]`, so PRs targeting `next` (including release-please bot PRs like #125) skipped the unit tests / PHPStan / PHPCS / build-assets matrix entirely. Only the `polish` workflow ran, leaving `next` release PRs blocked on required checks that were never scheduled.
- Add `next` to the branches list so CI fires on every PR into `next`.

Note: this lands on `next`, but PR #125 itself was opened before the workflow change. To re-trigger CI on #125 after merge, push an empty commit to its head branch or close/reopen the PR — `pull_request` events evaluate triggers from the workflow file on the base branch as of the event.

E2E coverage remains post-merge (invoked from `release-please-next.yml` on push). Wiring `e2e.yml` into PRs is a separate policy call and not part of this change.

## Test plan
- [ ] After merge, push an empty commit to the PR #125 head branch and confirm `Build Assets`, `Unit Tests (PHP 8.3/8.4/8.5)`, `PHPStan`, and `WordPress Code Style` all run.
- [ ] Confirm `polish` still runs alongside the new checks.
- [ ] Confirm CI does not regress on existing PRs to `main` or `dev`.