### PR TITLE
ci(release): add Attach Release Asset workflow

### DIFF
--- a/.github/scripts/build-dist.sh
+++ b/.github/scripts/build-dist.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build the MilliCache dist/ directory: exports tracked files, scopes
+# dependencies via Strauss, and regenerates the autoloader. Shared by
+# release-bundle.yml, manual-release.yml, and attach-release-asset.yml.
+# Run from the repo root. Assumes build/ assets are already present
+# (CI commits them; locally you'd run `npm run build` first).
+#
+# REF (env, default HEAD): git ref whose tree is exported into dist/.
+# Lets the attach-release-asset workflow build at a historical tag
+# while running the script from a newer branch.
+set -euo pipefail
+
+REF="${REF:-HEAD}"
+STRAUSS_VERSION="${STRAUSS_VERSION:-0.26.5}"
+STRAUSS_URL="https://github.com/BrianHenryIE/strauss/releases/download/${STRAUSS_VERSION}/strauss.phar"
+
+rm -rf dist && mkdir dist
+
+git archive --format=tar "$REF" | tar -x -C dist
+
+mkdir -p dist/bin
+curl -sL "$STRAUSS_URL" -o dist/bin/strauss.phar
+
+composer install --no-dev --no-interaction --no-scripts --prefer-dist --working-dir=dist
+
+(cd dist && php bin/strauss.phar -q)
+
+sed -i 's/namespace MilliRules\\Builders;/namespace MilliCache\\Deps\\MilliRules\\Builders;/' dist/stubs/*.php
+
+jq '.autoload.classmap = ["deps/"]' dist/composer.json > dist/composer.json.tmp \
+  && mv dist/composer.json.tmp dist/composer.json
+
+composer dump-autoload --no-dev --optimize --classmap-authoritative --no-scripts --working-dir=dist
+
+rm -rf dist/bin
+rm -f dist/composer.json dist/composer.lock
+
+echo "Dist contents:"
+ls -la dist/

--- a/.github/workflows/attach-release-asset.yml
+++ b/.github/workflows/attach-release-asset.yml
@@ -1,0 +1,67 @@
+name: Attach Release Asset
+
+# Builds millicache.zip at the given tag and uploads it to that tag's
+# existing GitHub release, leaving the release name, body, and prerelease
+# flag untouched. Use when a release was cut without an asset (e.g. an
+# older tag from before the build pipeline existed) and you want to
+# back-fill the bundle without disturbing the changelog.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to bundle and attach (e.g., v1.7.0-beta)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  attach:
+    name: Build & attach asset
+    runs-on: ubuntu-latest
+
+    steps:
+      # Check out the workflow's source branch (not the tag) so the build
+      # script is on disk. The script then archives the tag's tree via
+      # the REF env var below. fetch-tags ensures the requested tag is
+      # available locally for `git archive`.
+      - name: Checkout workflow source
+        uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Build dist at tag
+        env:
+          REF: ${{ inputs.tag }}
+        run: ./.github/scripts/build-dist.sh
+
+      - name: Create release archive
+        run: |
+          cd dist
+          zip -rq "../millicache.zip" .
+
+      - name: Upload asset to existing release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: gh release upload "$TAG" millicache.zip --clobber
+
+      - name: Summary
+        env:
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          {
+            echo "## Asset attached to ${TAG}"
+            echo ""
+            echo "[View Release](https://github.com/${REPO}/releases/tag/${TAG})"
+          } >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/attach-release-asset.yml` — a `workflow_dispatch` workflow that builds `millicache.zip` at a given tag and uploads it to that tag's existing GitHub release, leaving the release name, body, and prerelease flag untouched.
- Adds `.github/scripts/build-dist.sh` — the shared dist build (Strauss + composer + autoloader regen). It's `REF`-aware so it can build at a historical tag while running from a newer branch.

## Why on main and not just next

GitHub looks up workflow files by name on the **default branch** when dispatching via `gh workflow run` or the API. Without these two files on `main`, the workflow returns 404 even with `--ref next`.

The full DRY refactor (`release-bundle.yml` + slimmed callers) lives on the `next` branch and will land on `main` when 1.7.0 graduates. This PR is intentionally narrow: just the minimum to make the attach workflow dispatchable.

## Use case

Back-fill a release that was cut without an asset. Immediate target: `v1.7.0-beta`, which was tagged before this build pipeline existed. Reusable for any future case.

## Test plan

After merge:
- [ ] `gh workflow run attach-release-asset.yml -f tag=v1.7.0-beta`
- [ ] Confirm `millicache.zip` appears on the v1.7.0-beta release page
- [ ] Confirm release name, body, and prerelease flag are unchanged