### PR TITLE
ci(release): fix release-please-config-next.json leak in dist bundle

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,7 @@ php*.*                      export-ignore
 playwright.*                export-ignore
 composer.lock               export-ignore
 README.md                   export-ignore
-release-please-config.json  export-ignore
+release-please-config*.json export-ignore
 docs/                       export-ignore
 assets/                     export-ignore
 tests/                      export-ignore

--- a/.github/scripts/build-dist.sh
+++ b/.github/scripts/build-dist.sh
@@ -18,6 +18,13 @@ rm -rf dist && mkdir dist
 
 git archive --format=tar "$REF" | tar -x -C dist
 
+# Defensive cleanup: strip dev-only config that slipped past
+# export-ignore in older tags (e.g. release-please-config-next.json
+# was not covered by the singular pattern in v1.7.0-beta's
+# .gitattributes). Safe to run unconditionally — no-op for already-
+# clean trees.
+rm -f dist/release-please-config*.json
+
 mkdir -p dist/bin
 curl -sL "$STRAUSS_URL" -o dist/bin/strauss.phar
 


### PR DESCRIPTION
## Summary

Fixes a leak where `release-please-config-next.json` ships inside `millicache.zip`. Two complementary changes:

- **`.gitattributes`**: broaden `release-please-config.json` → `release-please-config*.json` so the `-next` variant (and any future suffixed variant) is excluded from `git archive` output.
- **`.github/scripts/build-dist.sh`**: defensively `rm -f dist/release-please-config*.json` after the archive extract. Required for the attach-release-asset workflow when back-filling older tags (e.g. `v1.7.0-beta`) — those tags carry the older, narrower `.gitattributes` and we cannot retroactively change them. Doubles as belt-and-suspenders for any future tag where export-ignore was missed.

## Why both, not just one

- `.gitattributes` alone would fix all *future* releases but not back-fills of old tags.
- The script `rm -f` alone would fix back-fills but leave the canonical export path stale.

## Test plan

- [x] Trigger `attach-release-asset.yml` against `v1.7.0-beta` after merge
- [x] Inspect the produced `millicache.zip` — confirm no `release-please-config*.json` file inside
- [x] Confirm release name/body unchanged