### PR TITLE
docs: Fix HIT/MISS comparison

### DIFF
--- a/docs/05-usage/10-how-caching-works.md
+++ b/docs/05-usage/10-how-caching-works.md
@@ -228,7 +228,7 @@ By default, these don't affect the cache key:
 | Metric           | Cache Hit  | Cache Miss        |
 |------------------|------------|-------------------|
 | Response Time    | 5-15ms     | 200-2000ms        |
-| PHP Execution    | None       | Full WordPress    |
+| PHP Execution    | Minimal    | Full WordPress    |
 | Database Queries | 0          | Typically 20-100+ |
 | Memory Usage     | Minimal    | Full application  |
 


### PR DESCRIPTION
"None" is a bit misleading and not 100% accurate :) 

When cache is served with `advanced-cache.php`, although the footprint is very minimal, you're still serving it though PHP, firing a PHP process, running shutdown handlers, etc.
