### PR TITLE
ci: migrate create-github-app-token to client-id input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
            github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.MILLIPRESS_BOT_APP_ID }}
+          client-id: ${{ secrets.MILLIPRESS_BOT_CLIENT_ID }}
           private-key: ${{ secrets.MILLIPRESS_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6
@@ -88,7 +88,7 @@ jobs:
           fi
           if [ -z "$APP_TOKEN" ]; then
             echo "::error::App installation token is not available."
-            echo "::error::For Dependabot PRs: ensure MILLIPRESS_BOT_APP_ID and MILLIPRESS_BOT_PRIVATE_KEY are exposed under Settings → Secrets and variables → Dependabot so the rebuild can be auto-pushed back to the PR branch."
+            echo "::error::For Dependabot PRs: ensure MILLIPRESS_BOT_CLIENT_ID and MILLIPRESS_BOT_PRIVATE_KEY are exposed under Settings → Secrets and variables → Dependabot so the rebuild can be auto-pushed back to the PR branch."
             git --no-pager diff --stat build/
             exit 1
           fi


### PR DESCRIPTION
## What

Switch the Build Assets token step on `main` from the deprecated `app-id` input to `client-id` (`create-github-app-token@v3`), reading `MILLIPRESS_BOT_CLIENT_ID` instead of `MILLIPRESS_BOT_APP_ID`.

## Why

Dependabot PRs target `main` (the default branch) and replay **main's** workflow. The Build Assets job mints a GitHub App token, but Dependabot runs read from a **separate Dependabot secret store** — which carries `MILLIPRESS_BOT_CLIENT_ID` + `MILLIPRESS_BOT_PRIVATE_KEY` but **not** `MILLIPRESS_BOT_APP_ID`. So `app-id` resolved empty and `create-github-app-token` aborted before the rebuild push, failing the Build Assets check on every Dependabot PR (e.g. #136).

This is a cherry-pick of `edc0ab709` (already on `next`) — bringing `main` in line. The original commit's `polish-release-pr.yml` hunk is omitted since that workflow doesn't exist on `main`.

## Effect

- Unblocks the Build Assets check on Dependabot PRs against `main`, including #136.
- No source/test changes — workflow YAML only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)