### PR TITLE
ci(dependabot): target the next branch instead of main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: "composer"
     directory: "/"
+    # Open PRs against the active dev branch, not the default branch (main)
+    target-branch: "next"
     schedule:
       interval: "weekly"
     groups:
@@ -24,6 +26,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "next"
     schedule:
       interval: "monthly"
     groups:
@@ -33,5 +36,6 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "next"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## What

Add `target-branch: "next"` to all three Dependabot ecosystems (composer, npm, github-actions) so dependency PRs are opened against `next` instead of the default branch `main`.

## Why this must live on `main`

Dependabot reads `.github/dependabot.yml` **only from the default branch** (`main`); the `target-branch` field then redirects where PRs are raised. So the companion commit on `next` (41b6033ce) has no effect on its own — this PR is what actually activates the behavior.

## Motivation

MilliCache develops on `next` and releases to `main` via release-please. Dependabot defaulting to `main` meant bumps landed ahead of the dev branch and ran main's (often-lagging) workflow — e.g. the `create-github-app-token` `client-id` migration sat on `next` for weeks while Dependabot PRs against `main` kept failing the Build Assets check (#136). Targeting `next` keeps bumps on the branch that's always current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)