### PR TITLE
fix(engine): accept Vary tokens covered by request keying or inert on GET

### DIFF
--- a/src/Engine/Request/Bucket/Resolver.php
+++ b/src/Engine/Request/Bucket/Resolver.php
@@ -139,9 +139,12 @@ final class Resolver {
 	/**
 	 * Resolve the Authorization-header bucket.
 	 *
-	 * Each unique Authorization header maps to a per-value bucket so
+	 * Each unique Authorization credential maps to a per-value bucket so
 	 * authenticated requests don't share cache entries with each other or
-	 * with anonymous requests.
+	 * with anonymous requests. Reads `HTTP_AUTHORIZATION` first, then the
+	 * channels SAPIs use when the raw header is stripped from the CGI
+	 * environment: `REDIRECT_HTTP_AUTHORIZATION` (Apache rewrite shim) and
+	 * the `PHP_AUTH_USER`/`PHP_AUTH_PW` pair (mod_php basic auth).
 	 *
 	 * @since 1.7.0
 	 *
@@ -149,11 +152,24 @@ final class Resolver {
 	 */
 	private function resolve_authorization(): ?string {
 		$auth = ServerVars::get( 'HTTP_AUTHORIZATION' );
-		if ( empty( $auth ) ) {
+
+		if ( '' === $auth ) {
+			$auth = ServerVars::get( 'REDIRECT_HTTP_AUTHORIZATION' );
+		}
+
+		if ( '' === $auth ) {
+			$user = ServerVars::get( 'PHP_AUTH_USER' );
+			$pw   = ServerVars::get( 'PHP_AUTH_PW' );
+			if ( '' !== $user || '' !== $pw ) {
+				$auth = $user . ':' . $pw;
+			}
+		}
+
+		if ( '' === $auth ) {
 			return null;
 		}
 
-		return md5( (string) $auth );
+		return md5( $auth );
 	}
 
 	/**

--- a/src/Engine/Response/Processor.php
+++ b/src/Engine/Response/Processor.php
@@ -200,10 +200,12 @@ final class Processor {
 	/**
 	 * Decide whether to bypass storage entirely based on Vary directives.
 	 *
-	 * Vary: *, Vary: Cookie, and Vary on any header outside the supported
-	 * allowlist (Accept, Accept-Encoding) make a response unsafe to cache
-	 * without a richer keying mechanism. Returns a human-readable bypass
-	 * reason when storage should be skipped, or null to proceed.
+	 * Allowed tokens are either covered by request keying (Host,
+	 * Authorization via the auth bucket, Accept via the optional accept
+	 * bucket, Accept-Encoding via gzip storage) or describe request bodies
+	 * that cacheable GET/HEAD requests do not carry (Content-Type,
+	 * Content-Length). Vary: Cookie bypasses on purpose: caching
+	 * per-cookie responses would fragment storage into per-visitor entries.
 	 *
 	 * @since 1.6.0
 	 *
@@ -211,7 +213,7 @@ final class Processor {
 	 * @return string|null Bypass reason, or null to allow caching.
 	 */
 	private function should_bypass_for_vary( array $headers ): ?string {
-		$vary = $this->extract_header_value( $headers, 'vary' );
+		$vary = implode( ',', $this->extract_header_values( $headers, 'vary' ) );
 		if ( '' === $vary ) {
 			return null;
 		}
@@ -222,7 +224,14 @@ final class Processor {
 			return 'Vary: * is uncacheable';
 		}
 
-		$allowed = array( 'accept', 'accept-encoding' );
+		$allowed = array(
+			'host',
+			'accept',
+			'accept-encoding',
+			'authorization',
+			'content-type',
+			'content-length',
+		);
 		foreach ( $tokens as $token ) {
 			if ( ! in_array( $token, $allowed, true ) ) {
 				return 'Vary: ' . $token . ' is not supported';
@@ -233,29 +242,31 @@ final class Processor {
 	}
 
 	/**
-	 * Extract a single header value from a "Key: Value" header list.
+	 * Extract all values of a named header from a "Key: Value" header list.
 	 *
-	 * Returns the trimmed value of the last occurrence of the named header
-	 * (matching is case-insensitive). Returns an empty string when missing.
+	 * Returns the trimmed values of every occurrence of the named header
+	 * (matching is case-insensitive), in source order. Multiple occurrences
+	 * of a list-valued header combine per RFC 9110 §5.2, so callers must
+	 * consider all of them, not just the last.
 	 *
 	 * @since 1.6.0
 	 *
 	 * @param array<string> $headers Header lines.
 	 * @param string        $name    Lowercase header name.
-	 * @return string Header value, or empty string.
+	 * @return array<string> Header values, empty when the header is missing.
 	 */
-	private function extract_header_value( array $headers, string $name ): string {
-		$value = '';
+	private function extract_header_values( array $headers, string $name ): array {
+		$values = array();
 		foreach ( $headers as $header ) {
 			if ( false === strpos( $header, ':' ) ) {
 				continue;
 			}
 			list( $key, $candidate ) = explode( ':', $header, 2 );
 			if ( strtolower( trim( $key ) ) === $name ) {
-				$value = trim( $candidate );
+				$values[] = trim( $candidate );
 			}
 		}
-		return $value;
+		return $values;
 	}
 
 	/**

--- a/tests/Unit/Engine/Request/HasherTest.php
+++ b/tests/Unit/Engine/Request/HasherTest.php
@@ -96,6 +96,43 @@ describe('Hasher', function () {
 			expect($hash1)->not->toBe($hash2);
 		});
 
+		it('includes redirected authorization header in hash', function () {
+			$hash1 = $this->hasher->generate();
+
+			$_SERVER['REDIRECT_HTTP_AUTHORIZATION'] = 'Bearer token123';
+			$hasher2 = new Hasher($this->config, $this->parser);
+			$hash2 = $hasher2->generate();
+
+			expect($hash1)->not->toBe($hash2);
+		});
+
+		it('includes basic auth credentials in hash when the raw header is stripped', function () {
+			$hash1 = $this->hasher->generate();
+
+			$_SERVER['PHP_AUTH_USER'] = 'alice';
+			$_SERVER['PHP_AUTH_PW']   = 'secret';
+			$hasher2 = new Hasher($this->config, $this->parser);
+			$hash2 = $hasher2->generate();
+
+			$_SERVER['PHP_AUTH_USER'] = 'bob';
+			$hasher3 = new Hasher($this->config, $this->parser);
+			$hash3 = $hasher3->generate();
+
+			expect($hash1)->not->toBe($hash2);
+			expect($hash2)->not->toBe($hash3);
+		});
+
+		it('prefers the raw authorization header over fallback channels', function () {
+			$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer token123';
+			$hash1 = (new Hasher($this->config, $this->parser))->generate();
+
+			$_SERVER['PHP_AUTH_USER'] = 'alice';
+			$_SERVER['PHP_AUTH_PW']   = 'secret';
+			$hash2 = (new Hasher($this->config, $this->parser))->generate();
+
+			expect($hash1)->toBe($hash2);
+		});
+
 		it('includes unique variables in hash', function () {
 			$config1 = new Config(
 				3600, 600, true, false,

--- a/tests/Unit/Engine/Response/ProcessorTest.php
+++ b/tests/Unit/Engine/Response/ProcessorTest.php
@@ -257,6 +257,80 @@ describe( 'ResponseManager', function () {
 		} );
 	} );
 
+	describe( 'vary bypass decision', function () {
+		// should_bypass_for_vary() is self-contained (no manager dependencies),
+		// so an instance without the constructor suffices.
+		$invoke = function ( array $headers ) {
+			$processor = ( new ReflectionClass( Processor::class ) )->newInstanceWithoutConstructor();
+			$method    = new ReflectionMethod( Processor::class, 'should_bypass_for_vary' );
+			$method->setAccessible( true );
+
+			return $method->invoke( $processor, $headers );
+		};
+
+		it( 'allows responses without a Vary header', function () use ( $invoke ) {
+			expect( $invoke( array( 'Content-Type: text/html' ) ) )->toBeNull();
+		} );
+
+		it( 'allows Vary on Accept and Accept-Encoding', function () use ( $invoke ) {
+			expect( $invoke( array( 'Vary: Accept-Encoding' ) ) )->toBeNull();
+			expect( $invoke( array( 'Vary: Accept, Accept-Encoding' ) ) )->toBeNull();
+		} );
+
+		it( 'allows Vary on headers covered by request keying', function () use ( $invoke ) {
+			expect( $invoke( array( 'Vary: Authorization' ) ) )->toBeNull();
+			expect( $invoke( array( 'Vary: Host' ) ) )->toBeNull();
+		} );
+
+		it( 'bypasses Vary: Cookie to avoid per-visitor fragmentation', function () use ( $invoke ) {
+			expect( $invoke( array( 'Vary: Cookie' ) ) )->toBe( 'Vary: cookie is not supported' );
+		} );
+
+		it( 'allows Vary on inert request-body headers', function () use ( $invoke ) {
+			expect( $invoke( array( 'Vary: Content-Type' ) ) )->toBeNull();
+			expect( $invoke( array( 'Vary: Accept-Encoding, Content-Type' ) ) )->toBeNull();
+			expect( $invoke( array( 'Vary: Content-Length' ) ) )->toBeNull();
+		} );
+
+		it( 'allows the exact Vary header Jetpack sends on every frontend request', function () use ( $invoke ) {
+			// Automattic\Jetpack\Status\Request::is_frontend(), see issue #172.
+			expect( $invoke( array( 'Vary: accept, content-type' ) ) )->toBeNull();
+		} );
+
+		it( 'matches tokens case-insensitively', function () use ( $invoke ) {
+			expect( $invoke( array( 'vary: ACCEPT-ENCODING , Host' ) ) )->toBeNull();
+		} );
+
+		it( 'bypasses Vary: * with its own reason', function () use ( $invoke ) {
+			expect( $invoke( array( 'Vary: *' ) ) )->toBe( 'Vary: * is uncacheable' );
+			expect( $invoke( array( 'Vary: Accept-Encoding, *' ) ) )->toBe( 'Vary: * is uncacheable' );
+		} );
+
+		it( 'bypasses unsupported tokens and names the offender', function () use ( $invoke ) {
+			expect( $invoke( array( 'Vary: X-Device' ) ) )->toBe( 'Vary: x-device is not supported' );
+			expect( $invoke( array( 'Vary: Accept-Encoding, Accept-Language' ) ) )->toBe( 'Vary: accept-language is not supported' );
+		} );
+
+		it( 'merges multiple Vary headers per RFC 9110', function () use ( $invoke ) {
+			$unsupported_last = array(
+				'Vary: Accept-Encoding',
+				'Vary: X-Device',
+			);
+			$unsupported_first = array(
+				'Vary: X-Device',
+				'Vary: Accept-Encoding',
+			);
+			expect( $invoke( $unsupported_last ) )->toBe( 'Vary: x-device is not supported' );
+			expect( $invoke( $unsupported_first ) )->toBe( 'Vary: x-device is not supported' );
+
+			$all_supported = array(
+				'Vary: Accept-Encoding',
+				'Vary: Accept',
+			);
+			expect( $invoke( $all_supported ) )->toBeNull();
+		} );
+	} );
+
 	describe( 'constructor signature', function () {
 		it( 'constructor takes 5 parameters', function () {
 			$method = new ReflectionMethod( Processor::class, '__construct' );


### PR DESCRIPTION
## Summary

Fast-tracked fix for #172: Jetpack sends `Vary: accept, content-type` on every frontend request (since Jetpack 12.2), which the Vary allowlist introduced in 1.6.0 rejected. Consequence: every site running Jetpack alongside MilliCache had zero page caching.

### Changes

- **Vary allowlist widened** (`Response\Processor`): now also accepts `authorization` and `host` (the request hash already varies on both, so every variant maps to its own entry) and `content-type`/`content-length` (inert: they describe request bodies, and only GET/HEAD requests can reach storage). `Vary: Cookie` keeps bypassing on purpose; such responses self-identify as per-cookie content and caching them would fragment storage into rarely-hit per-visitor entries retained for ttl+grace.
- **Multiple `Vary` headers merge per RFC 9110** instead of last-one-wins, so an allowed token can no longer mask a disallowed one emitted as a separate header line.
- **Authorization bucket hardened** (`Bucket\Resolver`): falls back to `REDIRECT_HTTP_AUTHORIZATION` and `PHP_AUTH_USER`/`PHP_AUTH_PW` on SAPIs that strip the raw header (Apache mod_php/CGI), so the `Vary: Authorization` allowlist entry is backed by real keying everywhere.

### Tests

- 13 new/updated unit tests, including a regression test pinning the exact header Jetpack emits.
- Full suite: 974 passing, PHPStan level 9 clean, PHPCS clean.

Fixes #172