### PR TITLE
Fix compatibility with TranslatePress

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -334,23 +334,109 @@ final class Engine {
 		// Create State object.
 		$context = Response\State::create( $hash );
 
-		// Get and return cached content (options applied in ResponseManager).
+		// Serve cached content. A fresh hit echoes the entry and exit()s inside
+		// the reader; only a MISS or a stale hit flagged for background
+		// regeneration returns control here.
 		$context = $this->response()->retrieve_and_serve_cache( $context );
 
-		// Start the output buffer.
-		add_action(
-			'template_redirect',
-			function () use ( $context ) {
-				if ( $this->check_cache_decision() ) {
-					// Apply any options set by rules.
-					$context = $this->options()->apply_to_state( $context );
+		// A fresh hit already exited — nothing left to capture.
+		if ( $context->was_cache_served() && ! $context->should_fcgi_regenerate() ) {
+			return;
+		}
 
-					// Start the output buffer.
+		// Register the response capture buffer (strategy resolved once plugins load).
+		$this->start_capture( $context );
+	}
+
+	/**
+	 * Register the response capture buffer.
+	 *
+	 * Whether an output-buffer post-processor such as TranslatePress is active
+	 * can only be known once plugins have loaded, so the strategy is resolved
+	 * on `init` at the lowest possible priority:
+	 *
+	 * - Default (no such plugin): keep the historical late buffer on
+	 *   `template_redirect` (PHP_INT_MAX - 10) — i.e. the innermost buffer.
+	 * - TranslatePress active: open the buffer here on `init`, ahead of
+	 *   TranslatePress' own `init` (priority 0) buffer, so MilliCache is the
+	 *   OUTERMOST buffer. TranslatePress then nests inside, flushes and
+	 *   translates first, and MilliCache captures the final translated HTML
+	 *   instead of the untranslated default language.
+	 *
+	 * TTL/grace/decision overrides from WP-typed rules are applied in the
+	 * buffer callback at flush time (Response\Processor::process_output_buffer()),
+	 * which runs at the end of the request — so opening the buffer early on the
+	 * outermost path loses nothing.
+	 *
+	 * @since 1.7.8
+	 *
+	 * @param Response\State $context The request state.
+	 * @return void
+	 */
+	private function start_capture( Response\State $context ): void {
+		add_action(
+			'init',
+			function () use ( $context ) {
+				if ( $this->needs_outermost_buffer() ) {
+					// Outermost: open now, ahead of init-phase post-processors.
 					$this->response()->start_output_buffer( $context );
+					return;
 				}
+
+				// Default: keep the historical innermost buffer.
+				add_action(
+					'template_redirect',
+					function () use ( $context ) {
+						if ( $this->check_cache_decision() ) {
+							// Apply any options set by rules.
+							$context = $this->options()->apply_to_state( $context );
+
+							// Start the output buffer.
+							$this->response()->start_output_buffer( $context );
+						}
+					},
+					PHP_INT_MAX - 10
+				);
 			},
-			PHP_INT_MAX - 10
+			PHP_INT_MIN
 		);
+	}
+
+	/**
+	 * Whether MilliCache must capture the outermost output buffer.
+	 *
+	 * True only for front-end page renders while TranslatePress — which opens
+	 * its translation buffer on `init` — is active. Being outermost lets
+	 * MilliCache capture the fully translated HTML instead of the untranslated
+	 * default language served on every cache hit otherwise.
+	 *
+	 * @since 1.7.8
+	 *
+	 * @return bool True when the outermost buffer strategy is required.
+	 */
+	private function needs_outermost_buffer(): bool {
+		// Only front-end page renders are buffered this way; leave admin and
+		// AJAX (and other non-page contexts) on the default path.
+		if ( is_admin() || ( function_exists( 'wp_doing_ajax' ) && wp_doing_ajax() ) ) {
+			return false;
+		}
+
+		$active = class_exists( 'TRP_Translate_Press', false );
+
+		/**
+		 * Filter whether MilliCache opens its capture buffer as the OUTERMOST
+		 * buffer (early, ahead of init-phase output-buffer post-processors)
+		 * instead of the default late/innermost buffer on `template_redirect`.
+		 *
+		 * Auto-enabled when TranslatePress is active. Return true to force it
+		 * for other output-buffer post-processors, or false to always keep the
+		 * historical behaviour.
+		 *
+		 * @since 1.7.8
+		 *
+		 * @param bool $needed Whether the outermost buffer is required.
+		 */
+		return (bool) apply_filters( 'millicache_capture_outermost_buffer', $active );
 	}
 
 	/**

--- a/src/Engine/Response/Processor.php
+++ b/src/Engine/Response/Processor.php
@@ -132,6 +132,26 @@ final class Processor {
 			return $output;
 		}
 
+		// When the buffer opens early (outermost, for TranslatePress), WP-typed
+		// rules have not run yet at open time, but they have all resolved by the
+		// time this callback flushes at end of request. Fold their
+		// TTL/grace/decision overrides into the state now. On the default
+		// template_redirect path the options were already applied, so this is a
+		// harmless no-op.
+		$this->state = Engine::instance()->options()->apply_to_state( $this->state );
+
+		// Honour a rule-driven bypass decided after the buffer opened.
+		$decision = $this->state->get_cache_decision();
+		if ( null !== $decision && false === $decision['decision'] ) {
+			if ( ! $this->state->should_fcgi_regenerate() ) {
+				$this->headers->set_status( 'bypass' );
+				if ( ! empty( $decision['reason'] ) ) {
+					$this->headers->set_reason( $decision['reason'] );
+				}
+			}
+			return $this->state->should_fcgi_regenerate() ? null : $output;
+		}
+
 		// Get all flags for this request.
 		$flags = $this->collect_flags();
 


### PR DESCRIPTION
# fix: capture the outermost output buffer when TranslatePress is active

## Summary

MilliCache opens its capture buffer very late — on `template_redirect` at priority `PHP_INT_MAX - 10` — which makes it the **innermost** output buffer. Any plugin that opens its own output buffer *earlier* (e.g. on `init`) becomes the **outer** buffer and post-processes the HTML **after** MilliCache has already snapshotted it. MilliCache therefore caches the *pre-processed* page.

One known victim currently is **TranslatePress**, which starts its translation buffer on `init` (priority 0):

- First request (MISS): the visitor sees the correctly translated page (TranslatePress translates on the way out, in its outer buffer). ✅
- What gets stored: the **untranslated, default-language** HTML (MilliCache's inner callback ran before TranslatePress translated). ❌
- Every subsequent request (HIT): the drop-in serves the stored default-language copy → wrong language. ❌

## Root cause

PHP flushes nested output buffers **LIFO — innermost first**. Because MilliCache opens last, its callback (`Response\Processor::process_output_buffer()`) runs first and captures the page before the outer buffers have transformed it.

```
Buffer stack (current):   [ TranslatePress (outer) [ MilliCache (inner) ] ]
Flush order (LIFO):       MilliCache stores raw HTML  →  TranslatePress translates for the browser
```

## Fix (opt-in, auto-enabled for TranslatePress)

The historical behaviour is **kept as the default**. Only when an `init`-phase output-buffer post-processor is detected — currently TranslatePress — does MilliCache switch to opening its buffer as the **outermost** one, so the post-processor nests inside and MilliCache captures the final, fully processed HTML.

```
Buffer stack (TranslatePress active):   [ MilliCache (outer) [ TranslatePress (inner) ] ]
Flush order (LIFO):                     TranslatePress translates  →  MilliCache stores translated HTML
```

### How the strategy is chosen

Whether TranslatePress is active is only knowable once plugins have loaded, so the choice is deferred to `init` at `PHP_INT_MIN` (which still runs *before* TranslatePress' own `init` priority-0 buffer):

- **Default / no post-processor:** register the historical late buffer on `template_redirect` (`PHP_INT_MAX - 10`) — behaviour is byte-for-byte unchanged, including the `check_cache_decision()` gate and `Options::apply_to_state()` call.
- **TranslatePress active (front-end page only):** open the buffer immediately on `init`, wrapping TranslatePress.

`Engine::run()` no longer registers the buffer directly; it calls a new `start_capture()` helper. A fresh cache hit still `exit()`s inside the reader, so the capture buffer is only set up for a MISS or a stale-hit background regeneration.

### Applying rule overrides on the outermost path

On the outermost path the buffer opens before WP-typed rules have resolved, so `Response\Processor::process_output_buffer()` now folds the rule-driven TTL/grace/decision overrides into the state at flush time (`Options::apply_to_state()`) and honours a rule-driven **bypass** decided after the buffer opened (returns the output unstored). This runs at end-of-request once every hook has fired, so nothing is missed. On the default path the options were already applied at `template_redirect`, so re-applying is a harmless no-op.

### Detection & override

```php
$active = class_exists( 'TRP_Translate_Press', false );
return (bool) apply_filters( 'millicache_capture_outermost_buffer', $active );
```

- `class_exists( 'TRP_Translate_Press', false )` is reliable at `init` — TranslatePress' main class is loaded during the plugin include, before `plugins_loaded`.
- The new filter `millicache_capture_outermost_buffer` lets integrators force the outermost strategy for other output-buffer post-processors, or disable it entirely:

```php
// Force it (e.g. for another init-phase HTML post-processor)
add_filter( 'millicache_capture_outermost_buffer', '__return_true' );

// Never use it
add_filter( 'millicache_capture_outermost_buffer', '__return_false' );
```

Admin and AJAX contexts are explicitly excluded, so only genuine front-end page renders use the outermost buffer. REST, XML-RPC, non-GET/HEAD and CLI requests are already short-circuited in the PHP-phase rules before `run()`, so they never reach this code.

## Why this is safe

- **No behaviour change without TranslatePress.** When no `init`-phase post-processor is present, the code path, hooks and priorities are identical to today.
- **Decision timing.** WP-typed rules run on `plugins_loaded`/`init`/`template_redirect`/`wp`, all before the buffer flushes at shutdown. Reading options at flush is at least as late as the old `template_redirect` read, so no override is missed.
- **PHP-level bypass unchanged.** `Engine::start()` still gates whether `run()` is called at all (XML-RPC, REST, non-GET/HEAD, CLI, files, nocache cookies/paths).
- **WP-level bypass preserved.** Logged-in / search / cron / AJAX / non-200 / `DONOTCACHEPAGE` decisions are enforced in the flush callback on the outermost path; a bypassed request simply passes its output through unstored.
- **Redirects aren't cached.** `Cache\Manager::cache_output()` validates status via `Writer::should_cache()`, so a 3xx captured by the earlier buffer is not stored.
- **Industry-standard approach.** Opening the capture buffer as the outermost one is what WP Rocket, WP Super Cache and W3TC do; it is the ecosystem norm precisely because it composes with output-buffer post-processors.

## Test plan

Environment: WordPress + TranslatePress (default `en_US` + a secondary language, e.g. `/de/`), MilliCache active with the drop-in installed.

1. **Reproduce (before patch):** Clear cache. Load `/de/some-page/` twice → first translated, second (HIT) default language. ❌
2. **Verify (after patch):** Clear cache. Load `/de/some-page/` twice → both translated; debug header shows `miss` then `hit`. ✅
3. **Default language:** `/some-page/` still caches and serves correctly.
4. **No cross-language contamination:** `/de/` and `/` produce distinct cache entries (request hash already includes the path).
5. **TranslatePress *not* installed:** confirm the buffer still opens on `template_redirect` (default path unchanged) and everything caches as before.
6. **Bypass:** logged-in user / search / `DONOTCACHEPAGE` on a translated page → `x-millicache: bypass`, nothing stored, page still translated.
7. **AJAX / REST:** front-end `admin-ajax.php` and REST requests are not wrapped by the outermost buffer (still translated by TranslatePress' own buffer).
8. **Stale-while-revalidate (FastCGI):** a stale hit serves instantly and the background regeneration stores the fresh translated page.
9. **Filter override:** `__return_false` reproduces the old bug (confirms toggle); `__return_true` forces the outermost path without TranslatePress.
10. Regression: run the existing PHPUnit suite; add cases asserting `needs_outermost_buffer()` is false by default / when `is_admin()`, and true when the class exists on a front-end request.

## Notes for maintainers

- Patch is against v1.7.7. `@since` tags use `1.7.8`; adjust to your release-please cut. Conventional-commit title suggested above (`fix:`).
- Touches only `src/Engine.php` (`run()` + new `start_capture()` / `needs_outermost_buffer()`) and `src/Engine/Response/Processor.php` (`process_output_buffer()`).
- Detection is intentionally TranslatePress-specific but filterable; happy to generalise to a registry of known `init`-phase post-processors if you prefer.
