### PR TITLE
feat(engine): capture the page in the outermost output buffer

### DIFF
--- a/docs/05-usage/10-how-caching-works.md
+++ b/docs/05-usage/10-how-caching-works.md
@@ -76,13 +76,15 @@ Response time: typically **5-15ms**.
 
 If no cache exists or content is expired:
 
-1. Let WordPress load normally
-2. Register WordPress Rules on `plugins_loaded`
-3. Start output buffering on `template_redirect` (priority 200)
-4. Evaluate WordPress Rules to either cache or bypass
+1. Start output buffering immediately, before any plugin loads
+2. Let WordPress load normally
+3. Register WordPress Rules on `plugins_loaded`
+4. Evaluate WordPress Rules on `template_redirect` to either cache or bypass
 5. Capture the complete response
-6. Store in Redis with flags
+6. Store in Redis with flags (only when the rules allowed caching)
 7. Send response to browser
+
+Because the buffer opens before any plugin, it is always the *outermost* buffer: plugins that transform the page in their own output buffer (translation plugins, HTML optimizers) run inside it, and the cache stores their final HTML. The rules decide whether a response is *stored*, not whether it is captured — a bypassed response simply passes through unstored.
 
 The first visitor to an uncached page pays this full render cost. [MilliCache Pro](https://www.millipress.com/millicache-pro/)'s [Cache Preloading](https://www.millipress.com/docs/millicache-pro/02-modules/05-cache-preloading/) avoids that by requesting pages in the background after publishing and after cache clears, so visitors always hit a warm cache.
 

--- a/docs/07-developers/01-architecture.md
+++ b/docs/07-developers/01-architecture.md
@@ -291,22 +291,30 @@ $cacheable = $request->is_cacheable();
        └─► Bootstrap rules evaluated
            └─► Request parsed and hashed
                └─► Cache lookup (Redis GET)
-                   └─► MISS: Continue to WordPress
+                   └─► MISS: Output buffering starts (outermost buffer)
+                       └─► Continue to WordPress
 
 2. plugins_loaded hook
    └─► WordPress rules registered
 
-3. template_redirect hook (priority 200)
+3. template_redirect hook
    └─► WordPress rules evaluated
-       └─► Output buffering starts
+       └─► Storage sentinel arms (response may be stored)
 
 4. shutdown hook
    └─► Output buffer captured
-       └─► Response validated
-           └─► Flags collected
-               └─► Cache stored (Redis SET)
-                   └─► Output sent to browser
+       └─► Rule decisions applied (bypass passes through unstored)
+           └─► Response validated
+               └─► Flags collected
+                   └─► Cache stored (Redis SET)
+                       └─► Output sent to browser
 ```
+
+The buffer opens before any plugin or mu-plugin loads, so output-buffer
+post-processors (translation plugins, HTML optimizers) always nest inside
+it and flush first: the cache captures their transformed HTML. Requests
+that never reach the `template_redirect` sentinel (admin screens, canonical
+redirects, early exits) pass through the buffer unstored.
 
 ## Extension Points
 

--- a/docs/07-developers/03-api-reference.md
+++ b/docs/07-developers/03-api-reference.md
@@ -476,7 +476,9 @@ add_action( 'membership_level_changed', function( $user_id, $new_level ) {
     ] );
 }, 10, 2 );
 
-// Short TTL for dynamic membership pages
+// Short TTL for dynamic membership pages. TTL, grace and cache-decision
+// calls are honored at any point up to the final buffer flush — even from
+// template code or shortcodes running after template_redirect.
 add_action( 'template_redirect', function() {
     if ( is_page( 'member-dashboard' ) ) {
         millicache_set_ttl( 300 );  // 5 minutes

--- a/docs/09-troubleshooting/01-common-issues.md
+++ b/docs/09-troubleshooting/01-common-issues.md
@@ -194,12 +194,30 @@ Error: Permission denied [unix:///var/run/redis/redis.sock]
    - **Excluded path?** Check `MC_CACHE_NOCACHE_PATHS`
    - **TTL = 0?** Check `MC_CACHE_TTL`
    - **Oversized response?** Responses larger than 5MB (before compression) are never stored
+   - **Redirect?** Responses with a 3xx status are never stored
+   - **Plugin-level compression?** A `Content-Encoding` reason means another plugin compresses the page inside PHP (e.g. `ob_gzhandler`). Disable that plugin's compression — server-level compression (nginx/Apache) is unaffected and preferred
 
 4. **Verify WP_CACHE:**
    ```bash
    wp config get WP_CACHE
    # Should be: true
    ```
+
+### Output Buffering Conflicts
+
+MilliCache captures pages in an output buffer that opens before any plugin
+loads, so plugins that post-process HTML in their own buffer (translation
+plugins, optimizers) are cached correctly. One situation needs attention:
+
+- **Streaming endpoints** (Server-Sent Events, long-polling, large file
+  downloads served on URLs without a file extension): these should never
+  run through a page cache. Add them to `MC_CACHE_NOCACHE_PATHS` so the
+  buffer is never opened for them.
+
+> [!NOTE]
+> With `display_errors` enabled, PHP notices printed during boot become part
+> of the captured page. Keep `display_errors` off in production (WordPress'
+> default) — notices belong in the error log.
 
 ### Cache Not Clearing
 

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -337,20 +337,8 @@ final class Engine {
 		// Get and return cached content (options applied in ResponseManager).
 		$context = $this->response()->retrieve_and_serve_cache( $context );
 
-		// Start the output buffer.
-		add_action(
-			'template_redirect',
-			function () use ( $context ) {
-				if ( $this->check_cache_decision() ) {
-					// Apply any options set by rules.
-					$context = $this->options()->apply_to_state( $context );
-
-					// Start the output buffer.
-					$this->response()->start_output_buffer( $context );
-				}
-			},
-			PHP_INT_MAX - 10
-		);
+		// Start the OUTERMOST output buffer and do some magic.
+		$this->response()->start_output_buffer( $context );
 	}
 
 	/**

--- a/src/Engine/Cache/Writer.php
+++ b/src/Engine/Cache/Writer.php
@@ -90,6 +90,15 @@ final class Writer {
 			);
 		}
 
+		// Don't cache redirects: a Location target set during rendering is
+		// request-specific and must never be replayed to other visitors.
+		if ( $status_code >= 300 && $status_code < 400 ) {
+			return array(
+				'cacheable' => false,
+				'reason'    => 'Redirect response',
+			);
+		}
+
 		return array(
 			'cacheable' => true,
 			'reason'    => '',

--- a/src/Engine/Response/Processor.php
+++ b/src/Engine/Response/Processor.php
@@ -16,6 +16,7 @@ use MilliCache\Engine;
 use MilliCache\Engine\Cache\Config;
 use MilliCache\Engine\Cache\Entry;
 use MilliCache\Engine\Cache\Manager as CacheManager;
+use MilliCache\Engine\Cache\Writer;
 use MilliCache\Engine\Flags;
 use MilliCache\Engine\Request\Processor as RequestManager;
 use MilliCache\Engine\Utilities\ServerVars;
@@ -80,6 +81,26 @@ final class Processor {
 	private RequestManager $request_manager;
 
 	/**
+	 * Sentinel decision: null until template_redirect fires, true when
+	 * storable, false when refused or the buffer was aborted (sticky).
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $storable = null;
+
+	/**
+	 * Set once PHP enters shutdown; a FINAL flush before then means a
+	 * third-party fastcgi_finish_request().
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var bool
+	 */
+	private bool $in_shutdown = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.0.0
@@ -107,6 +128,9 @@ final class Processor {
 	/**
 	 * Start output buffering for this request.
 	 *
+	 * Opened in the drop-in phase so MilliCache is the outermost buffer:
+	 * init-phase post-processors nest inside and flush before capture.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param State $context Request context.
@@ -114,22 +138,67 @@ final class Processor {
 	 */
 	public function start_output_buffer( State $context ): void {
 		$this->state = $context;
-		ob_start( array( $this, 'process_output_buffer' ) );
+
+		// Shutdown functions run before PHP finalizes output buffers; a
+		// FINAL arriving earlier is a third-party fastcgi_finish_request().
+		register_shutdown_function(
+			function () {
+				$this->in_shutdown = true;
+			}
+		);
+
+		add_action(
+			'template_redirect',
+			function () {
+				$this->mark_storable( Engine::instance()->check_cache_decision() );
+			},
+			PHP_INT_MAX - 10
+		);
+
+		// The chunk-size cap makes oversized responses overflow the buffer:
+		// the handler then runs without FINAL, aborts storage, and streams.
+		ob_start( array( $this, 'process_output_buffer' ), Writer::MAX_ENTRY_SIZE + 1 );
 	}
 
 	/**
 	 * Process output buffer callback.
 	 *
 	 * Caches the output if appropriate, sets headers, and returns the output.
+	 * Every path before the storable branch must stay free of WordPress
+	 * functions: it can run after a boot fatal, when only
+	 * wp-includes/plugin.php is loaded.
 	 *
 	 * @since 1.0.0
+	 * @since 1.8.0 Added the $phase parameter and abort semantics.
 	 *
 	 * @param string $output The buffered output.
+	 * @param int    $phase  Output-handler phase bitmask (PHP_OUTPUT_HANDLER_* flags).
 	 * @return string|null Output to send (null for background FCGI tasks).
 	 */
-	public function process_output_buffer( string $output ): ?string {
+	public function process_output_buffer( string $output, int $phase = 0 ): ?string {
+		// CLEAN (buffer discarded) or no FINAL (mid-request flush / chunk
+		// overflow): abort storage and pass the chunk through.
+		if ( 0 !== ( $phase & PHP_OUTPUT_HANDLER_CLEAN ) || 0 === ( $phase & PHP_OUTPUT_HANDLER_FINAL ) ) {
+			$this->storable = false;
+			return $output;
+		}
+
 		if ( ! $this->state ) {
 			return $output;
+		}
+
+		$regenerate = $this->state->should_fcgi_regenerate();
+
+		// Store only on the shutdown FINAL after a positive sentinel; an
+		// earlier FINAL means a third-party fastcgi_finish_request().
+		if ( true !== $this->storable || ! $this->in_shutdown ) {
+			return $regenerate ? null : $output;
+		}
+
+		// Fold in rule options set during rendering; a late bypass wins.
+		$this->state = Engine::instance()->options()->apply_to_state( $this->state );
+		if ( ! Engine::instance()->check_cache_decision() ) {
+			return $regenerate ? null : $output;
 		}
 
 		// Get all flags for this request.
@@ -152,14 +221,14 @@ final class Processor {
 		$regen_headers = $this->state->get_regen_headers();
 		$headers       = null !== $regen_headers ? $regen_headers : headers_list();
 
-		// Bypass storage entirely for unsupported Vary directives.
-		$vary_bypass = $this->should_bypass_for_vary( $headers );
-		if ( null !== $vary_bypass ) {
-			if ( ! $this->state->should_fcgi_regenerate() ) {
+		// Bypass storage entirely for unsupported Vary directives or encoded bodies.
+		$bypass = $this->should_bypass_storage( $headers );
+		if ( null !== $bypass ) {
+			if ( ! $regenerate ) {
 				$this->headers->set_status( 'bypass' );
 			}
-			$this->headers->set_reason( $vary_bypass );
-			return $this->state->should_fcgi_regenerate() ? null : $output;
+			$this->headers->set_reason( $bypass );
+			return $regenerate ? null : $output;
 		}
 
 		// Store the response. Identical bodies across variants are deduplicated
@@ -177,7 +246,7 @@ final class Processor {
 		);
 
 		// Set headers based on result.
-		if ( ! $result['cached'] && ! $this->state->should_fcgi_regenerate() ) {
+		if ( ! $result['cached'] && ! $regenerate ) {
 			$this->headers->set_status( 'bypass' );
 		}
 
@@ -188,7 +257,6 @@ final class Processor {
 
 		// Count a cacheable miss — but not the background regenerate of a
 		// stale hit (already counted as a hit), nor uncacheable responses.
-		$regenerate = $this->state->should_fcgi_regenerate();
 		if ( ! $regenerate && $result['cached'] ) {
 			$this->record_miss_metric( strlen( $output ) );
 		}
@@ -198,26 +266,54 @@ final class Processor {
 	}
 
 	/**
-	 * Decide whether to bypass storage entirely based on Vary directives.
+	 * Whether the response is still on track to be stored: the sentinel
+	 * fired positive and nothing aborted the buffer.
 	 *
-	 * Allowed tokens are either covered by request keying (Host,
+	 * @since 1.8.0
+	 *
+	 * @return bool
+	 */
+	public function is_storable(): bool {
+		return true === $this->storable;
+	}
+
+	/**
+	 * Record the template_redirect sentinel's cache decision. Sticky-negative:
+	 * once false, replays can never flip it back to positive.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param bool $storable Whether the sentinel decision allows storage.
+	 * @return void
+	 */
+	private function mark_storable( bool $storable ): void {
+		if ( false === $this->storable ) {
+			return;
+		}
+		$this->storable = $storable;
+	}
+
+	/**
+	 * Decide whether to bypass storage based on Vary and Content-Encoding.
+	 *
+	 * Allowed Vary tokens are either covered by request keying (Host,
 	 * Authorization via the auth bucket, Accept via the optional accept
 	 * bucket, Accept-Encoding via gzip storage) or describe request bodies
 	 * that cacheable GET/HEAD requests do not carry (Content-Type,
 	 * Content-Length). Vary: Cookie bypasses on purpose: caching
 	 * per-cookie responses would fragment storage into per-visitor entries.
 	 *
+	 * Any Content-Encoding also bypasses: the buffered bytes are not the
+	 * plain payload MilliCache stores and re-serves.
+	 *
 	 * @since 1.6.0
+	 * @since 1.8.0 Renamed from should_bypass_for_vary(), now also checks Content-Encoding.
 	 *
 	 * @param array<string> $headers Response headers ("Key: Value" strings).
 	 * @return string|null Bypass reason, or null to allow caching.
 	 */
-	private function should_bypass_for_vary( array $headers ): ?string {
-		$vary = implode( ',', $this->extract_header_values( $headers, 'vary' ) );
-		if ( '' === $vary ) {
-			return null;
-		}
-
+	private function should_bypass_storage( array $headers ): ?string {
+		$vary   = implode( ',', $this->extract_header_values( $headers, 'vary' ) );
 		$tokens = $this->parse_vary( $vary );
 
 		if ( in_array( '*', $tokens, true ) ) {
@@ -236,6 +332,11 @@ final class Processor {
 			if ( ! in_array( $token, $allowed, true ) ) {
 				return 'Vary: ' . $token . ' is not supported';
 			}
+		}
+
+		$encoding = implode( ', ', $this->extract_header_values( $headers, 'content-encoding' ) );
+		if ( '' !== $encoding ) {
+			return 'Content-Encoding: ' . $encoding . ' is not supported';
 		}
 
 		return null;
@@ -383,11 +484,11 @@ final class Processor {
 			$this->request_manager->process();
 		}
 
-		$vary_bypass = $this->should_bypass_for_vary( $headers );
-		if ( null !== $vary_bypass ) {
+		$bypass = $this->should_bypass_storage( $headers );
+		if ( null !== $bypass ) {
 			return array(
 				'cached' => false,
-				'reason' => $vary_bypass,
+				'reason' => $bypass,
 			);
 		}
 

--- a/tests/Integration/Engine/OutputBufferProbesTest.php
+++ b/tests/Integration/Engine/OutputBufferProbesTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Subprocess probes for the outermost output buffer.
+ *
+ * These run real PHP processes because the scenarios cannot be simulated
+ * inside the test runner: a boot fatal must happen WITHOUT the WordPress
+ * function mocks loaded (proving the handler's abort path is strictly
+ * WP-function-free), and the phase-semantics probe asserts engine-level
+ * ob_* behavior the capture buffer relies on.
+ *
+ * @package MilliCache
+ */
+
+/**
+ * Run a probe script in a fresh PHP process.
+ *
+ * @param string $script Absolute path to the probe script.
+ * @param string $args   Extra CLI arguments.
+ * @param bool   $stderr Whether to capture stderr too.
+ * @return array{output: string, code: int} Captured output and exit code.
+ */
+function millicache_run_probe( string $script, string $args = '', bool $stderr = false ): array {
+	$redirect = $stderr ? '2>&1' : '2>/dev/null';
+	$command  = sprintf(
+		'%s -d display_errors=1 -d error_reporting=E_ALL %s %s %s',
+		escapeshellarg( PHP_BINARY ),
+		escapeshellarg( $script ),
+		$args,
+		$redirect
+	);
+
+	exec( $command, $lines, $code );
+
+	return array(
+		'output' => implode( "\n", $lines ),
+		'code'   => $code,
+	);
+}
+
+describe( 'boot-fatal abort path', function () {
+	$probe = dirname( __DIR__, 2 ) . '/probe/boot-fatal-probe.php';
+
+	it( 'passes the error page through intact when boot dies via exit (dead-DB wp_die)', function () use ( $probe ) {
+		$result = millicache_run_probe( $probe, 'exit' );
+
+		expect( $result['code'] )->toBe( 0 );
+		expect( $result['output'] )->toBe( 'BOOT ERROR PAGE' );
+	} );
+
+	it( 'streams the page without a secondary fatal when boot fatals (broken drop-in)', function () use ( $probe ) {
+		$result = millicache_run_probe( $probe, 'fatal' );
+
+		// The client still receives the error page.
+		expect( $result['output'] )->toContain( 'BOOT ERROR PAGE' );
+
+		// Exactly ONE fatal: the simulated boot fatal. A second one would
+		// mean the output handler itself called into WordPress.
+		expect( substr_count( $result['output'], 'Fatal error' ) )->toBe( 1 );
+		expect( $result['output'] )->toContain( 'totally_undefined_wordpress_function' );
+		expect( $result['code'] )->toBe( 255 );
+	} );
+} );
+
+describe( 'output-buffer phase semantics', function () {
+	it( 'hold on the PHP version running the suite', function () {
+		$probe  = dirname( __DIR__, 2 ) . '/probe/ob-phase-semantics.php';
+		$result = millicache_run_probe( $probe, '', true );
+
+		expect( $result['code'] )->toBe( 0, 'Probe deviations: ' . $result['output'] );
+		expect( $result['output'] )->toContain( 'OK: output-buffer phase semantics verified' );
+	} );
+} );

--- a/tests/Unit/Core/StorageTest.php
+++ b/tests/Unit/Core/StorageTest.php
@@ -518,6 +518,44 @@ describe( 'Storage', function () {
 
 			expect( $result )->toBeFalse();
 		} );
+
+		it( 'sets regeneration locks with an expiry so aborted regens release themselves', function () {
+			$settings = array(
+				'host'       => '127.0.0.1',
+				'port'       => 6379,
+				'prefix'     => 'test',
+				'persistent' => false,
+			);
+
+			$storage = new Storage( $settings );
+
+			// A stub capturing the SET arguments. If a regeneration is
+			// aborted (buffer cleaned, mid-request flush), nothing ever
+			// unlocks explicitly; the EX TTL is what releases the lock.
+			$stub = new class() extends \Predis\Client {
+				/** @var array<int, mixed> */
+				public array $set_args = array();
+
+				public function set( ...$arguments ) {
+					$this->set_args = $arguments;
+					return 'OK';
+				}
+
+				public function __call( $command_id, $arguments ) {
+					return null;
+				}
+			};
+
+			$client_prop = new \ReflectionProperty( Storage::class, 'client' );
+			$client_prop->setAccessible( true );
+			$client_prop->setValue( $storage, $stub );
+
+			$result = $storage->lock( 'regen-hash' );
+
+			expect( $result )->toBeTrue();
+			expect( (string) $stub->set_args[0] )->toContain( 'regen-hash-lock' );
+			expect( array_slice( $stub->set_args, 2 ) )->toBe( array( 'EX', 30, 'NX' ) );
+		} );
 	} );
 
 	describe( 'Layer-1 fail-fast', function () {

--- a/tests/Unit/Engine/Cache/WriterTest.php
+++ b/tests/Unit/Engine/Cache/WriterTest.php
@@ -25,10 +25,15 @@ describe('Writer', function () {
 			expect($result['reason'])->toBe('');
 		});
 
-		it('allows caching for 3xx status codes', function () {
-			$result = $this->writer->should_cache(301);
+		it('disallows caching for 3xx status codes', function () {
+			// A Location target set during rendering is request-specific and
+			// must never be replayed to other visitors.
+			foreach (array(301, 302, 307, 308) as $status) {
+				$result = $this->writer->should_cache($status);
 
-			expect($result['cacheable'])->toBeTrue();
+				expect($result['cacheable'])->toBeFalse();
+				expect($result['reason'])->toBe('Redirect response');
+			}
 		});
 
 		it('allows caching for 4xx status codes', function () {

--- a/tests/Unit/Engine/EngineTest.php
+++ b/tests/Unit/Engine/EngineTest.php
@@ -432,3 +432,114 @@ describe( 'Engine', function () {
 		} );
 	} );
 } );
+
+/**
+ * Invoke the private Engine::run().
+ *
+ * @param Engine $engine The engine.
+ * @return void
+ */
+function millicache_invoke_engine_run( Engine $engine ): void {
+	$method = new ReflectionMethod( Engine::class, 'run' );
+	$method->setAccessible( true );
+	$method->invoke( $engine );
+}
+
+/**
+ * Find the sentinel callback recorded by the add_action() test mock.
+ *
+ * @return callable|null The template_redirect sentinel, or null.
+ */
+function millicache_find_sentinel(): ?callable {
+	global $test_actions;
+
+	foreach ( array_reverse( (array) $test_actions ) as $action ) {
+		if ( 'template_redirect' === $action['hook'] && PHP_INT_MAX - 10 === $action['priority'] ) {
+			return $action['callable'];
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Build an Engine whose storage always misses.
+ *
+ * @return Engine
+ */
+function millicache_engine_with_missing_storage(): Engine {
+	$storage = Mockery::mock( Storage::class );
+	$storage->shouldReceive( 'is_available' )->andReturn( false );
+
+	return new Engine( $storage );
+}
+
+describe( 'Engine output buffer', function () {
+
+	beforeEach( function () {
+		global $test_actions;
+		$test_actions = array();
+
+		$this->ob_base = ob_get_level();
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['HTTP_HOST']      = 'example.test';
+		$_SERVER['REQUEST_URI']    = '/engine-buffer-test/';
+	} );
+
+	afterEach( function () {
+		global $test_actions;
+		$test_actions = array();
+
+		while ( ob_get_level() > $this->ob_base ) {
+			@ob_end_clean();
+		}
+
+		// Don't leak an Engine built around a mocked Storage as the singleton.
+		$instance = new ReflectionProperty( Engine::class, 'instance' );
+		$instance->setAccessible( true );
+		$instance->setValue( null, null );
+	} );
+
+	it( 'run() opens the buffer immediately, before any template_redirect', function () {
+		$engine = millicache_engine_with_missing_storage();
+
+		millicache_invoke_engine_run( $engine );
+
+		expect( ob_get_level() )->toBe( $this->ob_base + 1 );
+
+		// Not storable until the sentinel fires.
+		expect( $engine->response()->is_storable() )->toBeFalse();
+	} );
+
+	it( 'sentinel records the decision, opens no second buffer across replays', function () {
+		$engine = millicache_engine_with_missing_storage();
+
+		millicache_invoke_engine_run( $engine );
+		$sentinel = millicache_find_sentinel();
+
+		expect( $sentinel )->not->toBeNull();
+
+		$sentinel();
+		$sentinel();
+
+		expect( $engine->response()->is_storable() )->toBeTrue();
+		expect( ob_get_level() )->toBe( $this->ob_base + 1 );
+	} );
+
+	it( 'keeps a negative sentinel sticky across replays', function () {
+		$engine = millicache_engine_with_missing_storage();
+		$engine->options()->set_cache_decision( false, 'test-bypass' );
+
+		millicache_invoke_engine_run( $engine );
+		$sentinel = millicache_find_sentinel();
+
+		$sentinel();
+		expect( $engine->response()->is_storable() )->toBeFalse();
+
+		// Flipping the decision positive afterwards must not resurrect it.
+		$engine->options()->set_cache_decision( true, '' );
+		$sentinel();
+		expect( $engine->response()->is_storable() )->toBeFalse();
+	} );
+} );

--- a/tests/Unit/Engine/Response/OutputBufferPhaseTest.php
+++ b/tests/Unit/Engine/Response/OutputBufferPhaseTest.php
@@ -1,0 +1,374 @@
+<?php
+/**
+ * Tests for the outermost output buffer's phase guards and storage gating.
+ *
+ * Covers Processor::process_output_buffer()'s abort semantics (CLEAN,
+ * missing FINAL, chunk-size overflow), the sticky-negative sentinel, the
+ * in-shutdown gate against third-party fastcgi_finish_request(), flush-time
+ * option application, and the Content-Encoding storage bypass.
+ *
+ * @link       https://www.millipress.com
+ * @since      1.8.0
+ *
+ * @package    MilliCache
+ */
+
+use MilliCache\Core\Storage;
+use MilliCache\Engine;
+use MilliCache\Engine\Cache\Manager as CacheManager;
+use MilliCache\Engine\Flags;
+use MilliCache\Engine\Request\Processor as RequestProcessor;
+use MilliCache\Engine\Response\Headers;
+use MilliCache\Engine\Response\Processor;
+use MilliCache\Engine\Response\State;
+use MilliCache\Engine\Utilities\Multisite;
+
+/**
+ * Create a Processor without running its constructor.
+ *
+ * The abort paths touch only the state property, so an instance without
+ * manager dependencies suffices; any accidental reach into an uninitialized
+ * typed property throws and fails the test, proving the path stayed cold.
+ *
+ * @param State|null $state Optional state to inject.
+ * @return Processor
+ */
+function millicache_bare_processor( ?State $state = null ): Processor {
+	$processor = ( new ReflectionClass( Processor::class ) )->newInstanceWithoutConstructor();
+	if ( null !== $state ) {
+		millicache_set_processor_prop( $processor, 'state', $state );
+	}
+	return $processor;
+}
+
+/**
+ * Set a private Processor property.
+ *
+ * @param Processor $processor The instance.
+ * @param string    $prop      Property name.
+ * @param mixed     $value     Value to set.
+ * @return void
+ */
+function millicache_set_processor_prop( Processor $processor, string $prop, $value ): void {
+	$ref = new ReflectionProperty( Processor::class, $prop );
+	$ref->setAccessible( true );
+	$ref->setValue( $processor, $value );
+}
+
+/**
+ * Simulate that PHP entered shutdown (normally set by the shutdown function
+ * registered in start_output_buffer()).
+ *
+ * @param Processor $processor The instance.
+ * @return void
+ */
+function millicache_enter_shutdown( Processor $processor ): void {
+	millicache_set_processor_prop( $processor, 'in_shutdown', true );
+}
+
+/**
+ * Invoke the private sentinel recorder (normally fired via the
+ * template_redirect closure registered in start_output_buffer()).
+ *
+ * @param Processor $processor The instance.
+ * @param bool      $storable  The sentinel decision to record.
+ * @return void
+ */
+function millicache_mark_storable( Processor $processor, bool $storable ): void {
+	$method = new ReflectionMethod( Processor::class, 'mark_storable' );
+	$method->setAccessible( true );
+	$method->invoke( $processor, $storable );
+}
+
+/**
+ * Build a fully wired Processor around a mocked Storage.
+ *
+ * @param Storage $storage Mocked storage instance.
+ * @return array{0: Processor, 1: RequestProcessor} Processor and its request manager.
+ */
+function millicache_full_processor( $storage ): array {
+	$config  = create_test_config();
+	$request = new RequestProcessor( $config );
+	$request->process();
+
+	$processor = new Processor(
+		$config,
+		new Flags( new Multisite() ),
+		new Headers( $config ),
+		new CacheManager( $config, $storage ),
+		$request
+	);
+
+	return array( $processor, $request );
+}
+
+uses()->beforeEach( function () {
+	$this->ob_base = ob_get_level();
+
+	$_SERVER['REQUEST_METHOD'] = 'GET';
+	$_SERVER['HTTP_HOST']      = 'example.test';
+	$_SERVER['REQUEST_URI']    = '/buffer-test/';
+
+	Engine::instance()->options()->reset();
+} );
+
+uses()->afterEach( function () {
+	while ( ob_get_level() > $this->ob_base ) {
+		@ob_end_clean();
+	}
+
+	Engine::instance()->options()->reset();
+	unset( $_SERVER['HTTP_USER_AGENT'] );
+} );
+
+describe( 'phase guard order', function () {
+
+	it( 'treats CLEAN|FINAL (ob_end_clean) as an abort, not a store', function () {
+		$processor = millicache_bare_processor( State::create( 'hash' ) );
+		millicache_mark_storable( $processor, true );
+		millicache_enter_shutdown( $processor );
+
+		$out = $processor->process_output_buffer( 'x', PHP_OUTPUT_HANDLER_CLEAN | PHP_OUTPUT_HANDLER_FINAL );
+
+		expect( $out )->toBe( 'x' );
+		expect( $processor->is_storable() )->toBeFalse();
+	} );
+
+	it( 'aborts and returns the chunk as a string when FINAL is absent', function () {
+		$processor = millicache_bare_processor( State::create( 'hash' ) );
+		millicache_mark_storable( $processor, true );
+
+		$out = $processor->process_output_buffer( 'chunk', PHP_OUTPUT_HANDLER_START | PHP_OUTPUT_HANDLER_FLUSH );
+
+		expect( $out )->toBe( 'chunk' );
+		expect( $out )->toBeString();
+		expect( $processor->is_storable() )->toBeFalse();
+	} );
+
+	it( 'refuses storage on FINAL before shutdown (third-party fastcgi_finish_request)', function () {
+		$processor = millicache_bare_processor( State::create( 'hash' ) );
+		millicache_mark_storable( $processor, true );
+
+		$out = $processor->process_output_buffer( 'page', PHP_OUTPUT_HANDLER_FINAL );
+
+		expect( $out )->toBe( 'page' );
+	} );
+
+	it( 'returns null on FINAL for an aborted background regeneration', function () {
+		$state     = State::create( 'hash' )->with_fcgi_regenerate( true );
+		$processor = millicache_bare_processor( $state );
+		millicache_mark_storable( $processor, true );
+		millicache_enter_shutdown( $processor );
+
+		// Abort first (e.g. a mid-request flush), then the final flush.
+		$processor->process_output_buffer( 'chunk', PHP_OUTPUT_HANDLER_START | PHP_OUTPUT_HANDLER_FLUSH );
+		$out = $processor->process_output_buffer( 'page', PHP_OUTPUT_HANDLER_FINAL );
+
+		expect( $out )->toBeNull();
+	} );
+} );
+
+describe( 'sentinel stickiness', function () {
+
+	it( 'never flips a negative back to positive', function () {
+		$processor = millicache_bare_processor();
+		millicache_mark_storable( $processor, false );
+		millicache_mark_storable( $processor, true );
+
+		expect( $processor->is_storable() )->toBeFalse();
+	} );
+
+	it( 'lets a later negative win over an earlier positive', function () {
+		$processor = millicache_bare_processor();
+		millicache_mark_storable( $processor, true );
+		millicache_mark_storable( $processor, false );
+
+		expect( $processor->is_storable() )->toBeFalse();
+	} );
+} );
+
+describe( 'real buffer interactions', function () {
+
+	it( 'survives a third-party while(ob_get_level()) ob_end_clean() loop', function () {
+		$processor = millicache_bare_processor();
+		millicache_mark_storable( $processor, true );
+		$processor->start_output_buffer( State::create( 'hash' ) );
+
+		echo 'partial output';
+
+		while ( ob_get_level() > $this->ob_base ) {
+			ob_end_clean();
+		}
+
+		expect( $processor->is_storable() )->toBeFalse();
+
+		// A sentinel firing after the abort cannot resurrect storability.
+		millicache_mark_storable( $processor, true );
+		expect( $processor->is_storable() )->toBeFalse();
+	} );
+
+	it( 'streams mid-request ob_flush() output intact and aborts storage', function () {
+		ob_start();
+
+		$processor = millicache_bare_processor();
+		millicache_mark_storable( $processor, true );
+		millicache_enter_shutdown( $processor );
+		$processor->start_output_buffer( State::create( 'hash' ) );
+
+		echo 'chunk-one ';
+		ob_flush();
+		echo 'chunk-two';
+		ob_end_flush();
+
+		$streamed = ob_get_clean();
+
+		expect( $streamed )->toBe( 'chunk-one chunk-two' );
+		expect( $processor->is_storable() )->toBeFalse();
+	} );
+
+	it( 'streams responses over the cache limit without storing (chunk overflow)', function () {
+		ob_start();
+
+		$processor = millicache_bare_processor();
+		// Sentinel positive and in shutdown: if the overflow abort failed,
+		// the storable path would hit an uninitialized manager and throw.
+		millicache_mark_storable( $processor, true );
+		millicache_enter_shutdown( $processor );
+		$processor->start_output_buffer( State::create( 'hash' ) );
+
+		$megabyte = str_repeat( 'a', 1048576 );
+		for ( $i = 0; $i < 6; $i++ ) {
+			echo $megabyte;
+		}
+		ob_end_flush();
+
+		$streamed = ob_get_clean();
+
+		expect( strlen( $streamed ) )->toBe( 6 * 1048576 );
+		expect( $processor->is_storable() )->toBeFalse();
+	} );
+} );
+
+describe( 'flush-time decisions', function () {
+
+	it( 'honors a late do_cache(false) set during rendering', function () {
+		Engine::instance()->options()->set_cache_decision( false, 'late-bypass' );
+
+		$processor = millicache_bare_processor( State::create( 'hash' ) );
+		millicache_mark_storable( $processor, true );
+		millicache_enter_shutdown( $processor );
+
+		$out = $processor->process_output_buffer( '<html>page</html>', PHP_OUTPUT_HANDLER_FINAL );
+
+		// Passed through unstored: the bare instance would have thrown on
+		// any reach into the cache manager.
+		expect( $out )->toBe( '<html>page</html>' );
+	} );
+
+	it( 'still refuses a late do_cache(true) after a sentinel negative', function () {
+		Engine::instance()->options()->set_cache_decision( true, 'too-late' );
+
+		$processor = millicache_bare_processor( State::create( 'hash' ) );
+		millicache_mark_storable( $processor, false );
+		millicache_enter_shutdown( $processor );
+
+		$out = $processor->process_output_buffer( '<html>page</html>', PHP_OUTPUT_HANDLER_FINAL );
+
+		expect( $out )->toBe( '<html>page</html>' );
+		expect( $processor->is_storable() )->toBeFalse();
+	} );
+} );
+
+describe( 'storable path', function () {
+
+	it( 'stores on the shutdown FINAL flush when the sentinel fired positive', function () {
+		// Internal UA short-circuits metrics recording.
+		$_SERVER['HTTP_USER_AGENT'] = 'MilliCache/tests';
+
+		$captured = null;
+		$storage  = Mockery::mock( Storage::class );
+		$storage->shouldReceive( 'is_available' )->andReturn( true );
+		$storage->shouldReceive( 'perform_cache' )->once()->andReturnUsing(
+			function ( $hash, $data, $flags, $cacheable ) use ( &$captured ) {
+				$captured = compact( 'hash', 'data', 'flags', 'cacheable' );
+				return true;
+			}
+		);
+
+		list( $processor, $request ) = millicache_full_processor( $storage );
+		millicache_set_processor_prop( $processor, 'state', State::create( $request->get_hasher()->get_hash() ?? '' ) );
+		millicache_mark_storable( $processor, true );
+		millicache_enter_shutdown( $processor );
+
+		$out = $processor->process_output_buffer( '<html>fresh page</html>', PHP_OUTPUT_HANDLER_FINAL );
+
+		expect( $out )->toBe( '<html>fresh page</html>' );
+		expect( $captured )->not->toBeNull();
+		expect( $captured['cacheable'] )->toBeTrue();
+	} );
+
+	it( 'regenerates unchanged: null return and stored-header reuse', function () {
+		$_SERVER['HTTP_USER_AGENT'] = 'MilliCache/tests';
+
+		$captured = null;
+		$storage  = Mockery::mock( Storage::class );
+		$storage->shouldReceive( 'is_available' )->andReturn( true );
+		$storage->shouldReceive( 'perform_cache' )->once()->andReturnUsing(
+			function ( $hash, $data, $flags, $cacheable ) use ( &$captured ) {
+				$captured = $data;
+				return true;
+			}
+		);
+
+		list( $processor, $request ) = millicache_full_processor( $storage );
+		$state = State::create( $request->get_hasher()->get_hash() ?? '' )
+			->with_fcgi_regenerate( true )
+			->with_regen_headers( array( 'Content-Type: text/html', 'X-Custom: kept' ) );
+		millicache_set_processor_prop( $processor, 'state', $state );
+		millicache_mark_storable( $processor, true );
+		millicache_enter_shutdown( $processor );
+
+		$out = $processor->process_output_buffer( '<html>regenerated</html>', PHP_OUTPUT_HANDLER_FINAL );
+
+		expect( $out )->toBeNull();
+		expect( $captured )->not->toBeNull();
+		expect( $captured['headers'] )->toContain( 'X-Custom: kept' );
+	} );
+
+	it( 'never stores responses carrying Content-Encoding', function () {
+		$storage = Mockery::mock( Storage::class );
+		$storage->shouldReceive( 'is_available' )->andReturn( true );
+		$storage->shouldNotReceive( 'perform_cache' );
+
+		list( $processor, $request ) = millicache_full_processor( $storage );
+		// Inject the encoded header set via the regen-header channel, which
+		// replaces headers_list() as the header source.
+		$state = State::create( $request->get_hasher()->get_hash() ?? '' )
+			->with_regen_headers( array( 'Content-Type: text/html', 'Content-Encoding: gzip' ) );
+		millicache_set_processor_prop( $processor, 'state', $state );
+		millicache_mark_storable( $processor, true );
+		millicache_enter_shutdown( $processor );
+
+		$out = $processor->process_output_buffer( "\x1f\x8bencoded", PHP_OUTPUT_HANDLER_FINAL );
+
+		expect( $out )->toBe( "\x1f\x8bencoded" );
+	} );
+
+	it( 'store() middleware path rejects Content-Encoding with a reason', function () {
+		$storage = Mockery::mock( Storage::class );
+		$storage->shouldReceive( 'is_available' )->andReturn( true );
+		$storage->shouldNotReceive( 'perform_cache' );
+
+		list( $processor ) = millicache_full_processor( $storage );
+
+		$result = $processor->store(
+			'pre-compressed body',
+			array( 'Content-Type: text/html', 'Content-Encoding: br' ),
+			200
+		);
+
+		expect( $result['cached'] )->toBeFalse();
+		expect( $result['reason'] )->toContain( 'Content-Encoding' );
+		expect( $result['reason'] )->toContain( 'br' );
+	} );
+} );

--- a/tests/Unit/Engine/Response/ProcessorTest.php
+++ b/tests/Unit/Engine/Response/ProcessorTest.php
@@ -184,13 +184,17 @@ describe( 'ResponseManager', function () {
 			expect( $returnType->getName() )->toBe( 'void' );
 		} );
 
-		it( 'process_output_buffer takes string parameter', function () {
+		it( 'process_output_buffer takes output string and phase bitmask', function () {
 			$method = new ReflectionMethod( Processor::class, 'process_output_buffer' );
 			$params = $method->getParameters();
 
-			expect( count( $params ) )->toBe( 1 );
+			expect( count( $params ) )->toBe( 2 );
 			expect( $params[0]->getName() )->toBe( 'output' );
 			expect( $params[0]->getType()->getName() )->toBe( 'string' );
+			expect( $params[1]->getName() )->toBe( 'phase' );
+			expect( $params[1]->getType()->getName() )->toBe( 'int' );
+			expect( $params[1]->isDefaultValueAvailable() )->toBeTrue();
+			expect( $params[1]->getDefaultValue() )->toBe( 0 );
 		} );
 
 		it( 'process_output_buffer returns nullable string', function () {
@@ -258,11 +262,11 @@ describe( 'ResponseManager', function () {
 	} );
 
 	describe( 'vary bypass decision', function () {
-		// should_bypass_for_vary() is self-contained (no manager dependencies),
+		// should_bypass_storage() is self-contained (no manager dependencies),
 		// so an instance without the constructor suffices.
 		$invoke = function ( array $headers ) {
 			$processor = ( new ReflectionClass( Processor::class ) )->newInstanceWithoutConstructor();
-			$method    = new ReflectionMethod( Processor::class, 'should_bypass_for_vary' );
+			$method    = new ReflectionMethod( Processor::class, 'should_bypass_storage' );
 			$method->setAccessible( true );
 
 			return $method->invoke( $processor, $headers );
@@ -309,6 +313,11 @@ describe( 'ResponseManager', function () {
 		it( 'bypasses unsupported tokens and names the offender', function () use ( $invoke ) {
 			expect( $invoke( array( 'Vary: X-Device' ) ) )->toBe( 'Vary: x-device is not supported' );
 			expect( $invoke( array( 'Vary: Accept-Encoding, Accept-Language' ) ) )->toBe( 'Vary: accept-language is not supported' );
+		} );
+
+		it( 'bypasses encoded bodies, merging multiple Content-Encoding headers', function () use ( $invoke ) {
+			expect( $invoke( array( 'Content-Encoding: gzip' ) ) )->toBe( 'Content-Encoding: gzip is not supported' );
+			expect( $invoke( array( 'Content-Encoding: gzip', 'content-encoding: identity' ) ) )->toBe( 'Content-Encoding: gzip, identity is not supported' );
 		} );
 
 		it( 'merges multiple Vary headers per RFC 9110', function () use ( $invoke ) {

--- a/tests/e2e/step16-early-buffer.spec.ts
+++ b/tests/e2e/step16-early-buffer.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from './setup/e2e-wp-test';
+import { clearCache, networkActivatePlugin } from './utils/tools';
+import { FrontendPage } from './pages';
+
+/**
+ * Step 16: Outermost Output Buffer
+ *
+ * MilliCache opens its capture buffer in the drop-in phase, making it the
+ * outermost output buffer. Post-processors that buffer on init (simulated
+ * by the init-ob-postprocessor mu-plugin, mirroring TranslatePress) nest
+ * inside it and flush first, so the cache stores the transformed HTML.
+ */
+
+const MARKER = '<!-- mc-e2e-init-ob -->';
+
+test.describe('Step 16: Outermost Output Buffer', () => {
+    test.beforeAll(async () => {
+        await networkActivatePlugin();
+        await clearCache('*');
+    });
+
+    test.describe('Init-phase post-processor capture', () => {
+        test('Post-processed HTML is served on miss and stored in the cache', async ({
+            page,
+        }) => {
+            await clearCache('*');
+            await page.context().clearCookies();
+
+            const frontend = new FrontendPage(page);
+
+            // Prime the cache: the visitor sees the post-processed page.
+            const missResponse = await frontend.goto('/hello-world/');
+            await expect(missResponse).toHaveCacheStatus(['miss', 'bypass']);
+            expect(await page.content()).toContain(MARKER);
+
+            // The regression assertion: the cached entry must contain the
+            // post-processed HTML, not the raw capture.
+            const hitResponse = await frontend.reload();
+            await expect(hitResponse).toBeCacheHit();
+            expect(await page.content()).toContain(MARKER);
+        });
+    });
+
+    test.describe('Never-storable paths stay uncached', () => {
+        test('Canonical redirects are not cached', async ({ page }) => {
+            await clearCache('*');
+
+            // WordPress 301-redirects the missing trailing slash on
+            // template_redirect:10 — before the storage sentinel fires.
+            for (let i = 0; i < 2; i++) {
+                const response = await page.request.get('/hello-world', {
+                    maxRedirects: 0,
+                });
+                expect(response.status()).toBe(301);
+                const status = response.headers()['x-millicache-status'];
+                expect(status).not.toBe('hit');
+            }
+        });
+    });
+});

--- a/tests/probe/boot-fatal-probe.php
+++ b/tests/probe/boot-fatal-probe.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Boot-fatal probe: simulates a request that dies before
+ * wp-includes/functions.php loads (dead-DB wp_die, broken object-cache
+ * drop-in) AFTER MilliCache opened its capture buffer in the drop-in phase.
+ *
+ * Deliberately loads NO WordPress function mocks: only ABSPATH and the
+ * Composer autoloader exist, so any WordPress function call on the output
+ * handler's abort path fatals and fails the parent test's assertions.
+ *
+ * Modes (argv[1]):
+ *  - 'exit'  wp_die-style: prints the error page, then exits cleanly.
+ *  - 'fatal' drop-in style: undefined-function Error during rendering.
+ *
+ * @package MilliCache
+ */
+
+define( 'ABSPATH', __DIR__ . '/../../' );
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+/**
+ * Stand-in for wp-includes/plugin.php, which wp-settings.php always loads
+ * BEFORE advanced-cache.php; it is the only WordPress API available when
+ * the capture buffer opens. Everything else stays undefined on purpose.
+ *
+ * @param string   $hook     Hook name.
+ * @param callable $callback Callback.
+ * @param int      $priority Priority.
+ * @return bool
+ */
+function add_action( $hook, $callback, $priority = 10 ) {
+	return true;
+}
+
+use MilliCache\Engine\Response\Processor;
+use MilliCache\Engine\Response\State;
+
+$mode = isset( $argv[1] ) ? $argv[1] : 'exit';
+
+$processor = ( new ReflectionClass( Processor::class ) )->newInstanceWithoutConstructor();
+
+// Mirror Engine::run(): the buffer opens in the drop-in phase (this also
+// registers the in-shutdown marker). The template_redirect sentinel never
+// fires in this scenario, so the handler must pass the error page through
+// on its WP-function-free path.
+$processor->start_output_buffer( State::create( 'boot-fatal-hash' ) );
+
+echo 'BOOT ERROR PAGE';
+
+if ( 'fatal' === $mode ) {
+	totally_undefined_wordpress_function();
+}
+
+exit( 0 );

--- a/tests/probe/ob-phase-semantics.php
+++ b/tests/probe/ob-phase-semantics.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Output-buffer phase-semantics probe.
+ *
+ * Asserts the PHP output-handler phase behavior MilliCache's capture buffer
+ * relies on. Runs against the current PHP as part of the test suite (see
+ * OutputBufferProbesTest); standalone on purpose (no Composer, no Pest,
+ * PHP 7.4-compatible syntax) so it can be run against any interpreter.
+ *
+ * The supported floor is settled: all probes pass on PHP 7.4.33 (the final
+ * 7.4 release, verified 2026-08-03), matching 8.4.16.
+ *
+ * Run: php tests/probe/ob-phase-semantics.php
+ * Exits non-zero listing every deviation.
+ *
+ * @package MilliCache
+ */
+
+$failures = array();
+
+/**
+ * Run a single probe, collecting assertion failures instead of aborting.
+ *
+ * @param string   $name The probe name.
+ * @param callable $fn   The probe body; throws RuntimeException on failure.
+ * @return void
+ */
+function probe( $name, callable $fn ) {
+	global $failures;
+
+	$level = ob_get_level();
+	try {
+		$fn();
+	} catch ( Throwable $e ) {
+		$failures[] = $name . ': ' . $e->getMessage();
+	}
+	while ( ob_get_level() > $level ) {
+		@ob_end_clean();
+	}
+}
+
+/**
+ * Minimal assertion helper.
+ *
+ * @param bool   $condition The condition that must hold.
+ * @param string $message   Failure message.
+ * @return void
+ */
+function check( $condition, $message ) {
+	if ( ! $condition ) {
+		throw new RuntimeException( $message );
+	}
+}
+
+probe(
+	'ob_clean invokes the handler with CLEAN, without FINAL',
+	function () {
+		$phases = array();
+		ob_start(
+			function ( $output, $phase ) use ( &$phases ) {
+				$phases[] = $phase;
+				return $output;
+			}
+		);
+		echo 'x';
+		ob_clean();
+
+		check( 1 === count( $phases ), 'handler was not called exactly once on ob_clean' );
+		check( 0 !== ( $phases[0] & PHP_OUTPUT_HANDLER_CLEAN ), 'CLEAN flag missing on ob_clean' );
+		check( 0 === ( $phases[0] & PHP_OUTPUT_HANDLER_FINAL ), 'FINAL flag unexpectedly set on ob_clean' );
+	}
+);
+
+probe(
+	'ob_end_clean invokes the handler with CLEAN|FINAL and emits nothing',
+	function () {
+		$phases = array();
+		ob_start();
+		ob_start(
+			function ( $output, $phase ) use ( &$phases ) {
+				$phases[] = $phase;
+				return $output;
+			}
+		);
+		echo 'x';
+		ob_end_clean();
+		$emitted = ob_get_clean();
+
+		check( 1 === count( $phases ), 'handler was not called exactly once on ob_end_clean' );
+		check( 0 !== ( $phases[0] & PHP_OUTPUT_HANDLER_CLEAN ), 'CLEAN flag missing on ob_end_clean' );
+		check( 0 !== ( $phases[0] & PHP_OUTPUT_HANDLER_FINAL ), 'FINAL flag missing on ob_end_clean' );
+		check( '' === $emitted, 'ob_end_clean emitted output' );
+	}
+);
+
+probe(
+	'chunk-size overflow invokes the handler without FINAL and without CLEAN',
+	function () {
+		$phases = array();
+		ob_start();
+		ob_start(
+			function ( $output, $phase ) use ( &$phases ) {
+				$phases[] = $phase;
+				return $output;
+			},
+			8
+		);
+		echo '0123456789';
+
+		check( count( $phases ) >= 1, 'handler was not called on chunk-size overflow' );
+		check( 0 === ( $phases[0] & PHP_OUTPUT_HANDLER_FINAL ), 'FINAL flag unexpectedly set on chunk overflow' );
+		check( 0 === ( $phases[0] & PHP_OUTPUT_HANDLER_CLEAN ), 'CLEAN flag unexpectedly set on chunk overflow' );
+	}
+);
+
+probe(
+	'mid-request ob_flush invokes the handler with FLUSH, without FINAL',
+	function () {
+		$phases = array();
+		ob_start();
+		ob_start(
+			function ( $output, $phase ) use ( &$phases ) {
+				$phases[] = $phase;
+				return $output;
+			}
+		);
+		echo 'x';
+		ob_flush();
+
+		check( 1 === count( $phases ), 'handler was not called exactly once on ob_flush' );
+		check( 0 !== ( $phases[0] & PHP_OUTPUT_HANDLER_FLUSH ), 'FLUSH flag missing on ob_flush' );
+		check( 0 === ( $phases[0] & PHP_OUTPUT_HANDLER_FINAL ), 'FINAL flag unexpectedly set on ob_flush' );
+	}
+);
+
+probe(
+	'null return suppresses output on FINAL',
+	function () {
+		ob_start();
+		ob_start(
+			function ( $output, $phase ) {
+				return null;
+			}
+		);
+		echo 'SHOULD NOT APPEAR';
+		ob_end_flush();
+		$emitted = ob_get_clean();
+
+		check( '' === $emitted, 'null handler return did not suppress output on FINAL' );
+	}
+);
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, 'Output-buffer phase semantics DEVIATE on PHP ' . PHP_VERSION . ":\n" );
+	foreach ( $failures as $failure ) {
+		fwrite( STDERR, ' - ' . $failure . "\n" );
+	}
+	exit( 1 );
+}
+
+echo 'OK: output-buffer phase semantics verified on PHP ' . PHP_VERSION . "\n";
+exit( 0 );

--- a/tests/wp-env/mu-plugins/init-ob-postprocessor.php
+++ b/tests/wp-env/mu-plugins/init-ob-postprocessor.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Plugin Name: Init-Phase Output-Buffer Post-Processor
+ * Description: Simulates plugins like TranslatePress that open an output buffer on init and transform the page HTML in their flush callback. MilliCache must capture the transformed HTML, so the marker has to appear in cached entries too.
+ * Version: 1.0.0
+ *
+ * @package MilliCacheTests
+ */
+
+add_action(
+    'init',
+    static function () {
+        // Frontend page renders only — mirrors TranslatePress' own scoping.
+        if (is_admin() || wp_doing_ajax() || wp_doing_cron()) {
+            return;
+        }
+
+        ob_start(
+            static function (string $output): string {
+                return str_replace('</body>', '<!-- mc-e2e-init-ob --></body>', $output);
+            }
+        );
+    },
+    0
+);


### PR DESCRIPTION
## Summary

MilliCache now opens its capture buffer in the drop-in phase (`advanced-cache.php`), before any plugin or mu-plugin loads, making it the **outermost** output buffer. Plugins that post-process HTML in their own buffer (TranslatePress, Weglot, HTML optimizers) nest inside it and flush first, so the cache stores their final HTML.

Previously the buffer opened last (`template_redirect` at `PHP_INT_MAX - 10`) and captured the page **before** those plugins transformed it: the first visitor saw the correct page, but every cache hit served the untransformed version (e.g. the untranslated default language).

Supersedes #180 — thanks @LukePPx for the report, root-cause analysis, and initial patch. Your `Processor` flush-time approach carried directly into this implementation.

## Design

- **Single code path, no escape hatch.** The buffer opens unconditionally in `Engine::run()` right after the cache lookup (cache hits still serve-and-exit before any buffer exists). The whole capture lifecycle lives in `Response\Processor::start_output_buffer()`.
- **Capture position moves, eligibility does not.** A sentinel remains at the exact `template_redirect PHP_INT_MAX - 10` slot where the buffer used to open: only requests that reach it with a positive cache decision may be stored, and the sentinel is sticky-negative across manual `do_action` replays. Admin screens, canonical redirects, early exits, and boot failures pass through unstored — identical storability to 1.7. The handler's passthrough paths are strictly WordPress-function-free, so even a dead-DB `wp_die()` page reaches the client intact (proven by a subprocess probe that runs without WordPress loaded).
- **Rule decisions apply at flush.** TTL/grace/bypass set by rules (or the options API) at any point up to the final flush are honored; a late bypass passes the output through unstored. A late `do_cache(true)` after a sentinel negative is still refused (sentinel AND flush decision).
- **Abort guards.** The handler receives the output-handler phase flags: a buffer cleaned or partially flushed by another plugin, a chunk overflow past the 5MB cap (the response streams instead of buffering), or a `fastcgi_finish_request()` issued mid-request by a third party (detected via an in-shutdown marker) all abort storage instead of caching partial content. Responses carrying a `Content-Encoding` (an in-PHP compressor nesting inside our buffer) are never stored, on both the buffer and the middleware `store()` paths.
- Separate commit: 3xx responses are never stored (pre-existing gap — a redirect issued during rendering could be cached and replayed).

## API

New public accessor for extensions: `millicache()->response()->is_storable()` — true only when the sentinel fired positive and nothing has aborted the buffer. (No new `Engine` facade method; refusing storage stays with the rules/options cache decision.)

## Verification

- **PHP output-handler semantics** verified on PHP 7.4.33 (the final 7.4 release, via Docker) and 8.4.16: handlers are invoked on clean *with* the CLEAN bit, chunk overflows arrive without FINAL, mid-request flushes lack FINAL, shutdown functions run before the FINAL flush, `null` on FINAL suppresses output. 7.4 and 8.4 behave identically. The probe (`tests/probe/ob-phase-semantics.php`) also runs inside the suite on every CI PHP version, so a future PHP deviation fails CI.
- **Unit + integration:** 1016 tests / 2049 assertions passing (new: phase guards, sticky sentinel, in-shutdown gate, flush-time decisions, Content-Encoding bypass, SWR regen header reuse, lock TTL, boot-fatal subprocess probes). PHPStan level 9 and PHPCS clean.
- **E2E:** full Playwright suite, 88 passed — including a new `step16` with a mu-plugin that opens an `ob_start` post-processor on `init` (the TranslatePress pattern): the marker appears in the MISS body **and** in the cached HIT body; canonical redirects never become hits. The whole existing suite (WooCommerce, rules, multisite, invalidation) ran with that post-processor active.

## Trade-offs (documented, intentional)

- Early boot output (`display_errors` notices, drop-in warnings) is captured into stored entries — keep `display_errors` off in production (noted in the troubleshooting docs).
- Sites running an init-phase `ob_gzhandler` become uncacheable via the Content-Encoding bypass (correct, but full coverage loss there; server-level compression is unaffected).
- `flush()`-only streaming endpoints (SSE) on extension-less URLs need `MC_CACHE_NOCACHE_PATHS`.

## Follow-up

MilliCache Pro's Edge Cache tagger currently uses `headers_sent()` as a cacheability heuristic; it will switch to `millicache()->response()->is_storable()` before 1.8.0 GA (tracked in the Pro repo).

BEGIN_COMMIT_OVERRIDE
feat(engine): capture the page in the outermost output buffer

Pages transformed by plugins that post-process HTML in their own output buffer (translation plugins such as TranslatePress, HTML optimizers) are now cached correctly: the capture buffer opens before any plugin loads, so those plugins nest inside it and their final HTML is what gets stored. Rule-driven TTL, grace, and bypass decisions are honored up to the final flush; buffers cleaned or flushed mid-request by other plugins abort storage instead of caching partial content. Thanks to @LukePPx for the report, analysis, and initial patch (#180).

fix(engine): never store redirect responses
END_COMMIT_OVERRIDE
