### PR TITLE
feat(storage): expose the shared body hash and meta size per cache entry

### DIFF
--- a/src/Core/Storage.php
+++ b/src/Core/Storage.php
@@ -220,7 +220,15 @@ class Storage {
 	 * Get cache entries (keyed by hash, flags always included). `$include_output`
 	 * also transfers the dereferenced output body.
 	 *
+	 * Bodies live in a content-addressable keyspace shared by every entry with
+	 * identical output, so `size` is the length of the body an entry points to,
+	 * not what the entry adds on its own. Each entry also carries its
+	 * `output_hash` (the body it references, empty when it has no body) and
+	 * `meta_size` (the byte length of its stored metadata), so callers can tell
+	 * which entries share a body and what a shared entry weighs by itself.
+	 *
 	 * @since 1.4.0
+	 * @since 1.8.3 Entries carry `output_hash` and `meta_size`.
 	 * @access public
 	 *
 	 * @param string $flag           Optional flag filter. Supports wildcards.
@@ -266,9 +274,11 @@ class Storage {
 						continue;
 					}
 
-					$entry         = $this->parse_meta( $values[0] );
-					$output_hash   = isset( $values[1] ) && is_string( $values[1] ) ? $values[1] : '';
-					$entry['size'] = 0;
+					$entry                = $this->parse_meta( $values[0] );
+					$output_hash          = isset( $values[1] ) && is_string( $values[1] ) ? $values[1] : '';
+					$entry['size']        = 0;
+					$entry['output_hash'] = $output_hash;
+					$entry['meta_size']   = strlen( $values[0] );
 
 					$entry['flags'] = array_map(
 						array( $this, 'toggle_flag_key' ),

--- a/tests/Unit/Core/StorageTest.php
+++ b/tests/Unit/Core/StorageTest.php
@@ -418,6 +418,118 @@ describe( 'Storage', function () {
 		} );
 	} );
 
+	describe( 'get_entries', function () {
+		it( 'exposes the shared body hash and the per-entry meta size', function () {
+			$settings = array(
+				'host'       => '127.0.0.1',
+				'port'       => 6379,
+				'prefix'     => 'test',
+				'persistent' => false,
+			);
+
+			$storage = new Storage( $settings );
+
+			// Two entries share one body, a third has its own, a fourth has no
+			// body at all. The stub answers each pipelined command from canned
+			// data so the whole read path runs without a server.
+			$stub = new class() extends \Predis\Client {
+				/** @var array<string, array<string, mixed>> */
+				public array $hashes = array(
+					'test:c:hashA' => array(
+						'meta'   => '{"url":"https://example.com/a","status":200}',
+						'output' => 'body1',
+					),
+					'test:c:hashB' => array(
+						'meta'   => '{"url":"https://example.com/a?utm=1","status":200,"variant":{"cookies":["x"]}}',
+						'output' => 'body1',
+					),
+					'test:c:hashC' => array(
+						'meta'   => '{"url":"https://example.com/c","status":200}',
+						'output' => 'body2',
+					),
+					'test:c:hashD' => array(
+						'meta' => '{"url":"https://example.com/d","status":301}',
+					),
+				);
+				/** @var array<string, int> */
+				public array $bodies = array(
+					'test:o:body1' => 1000,
+					'test:o:body2' => 2000,
+				);
+
+				public function pipeline( ...$arguments ) {
+					$callback = $arguments[0] ?? null;
+
+					$pipe = new class() {
+						/** @var array<int, array{0: string, 1: array<int, mixed>}> */
+						public array $queued = array();
+
+						public function __call( $command_id, $arguments ) {
+							$this->queued[] = array( strtolower( (string) $command_id ), $arguments );
+							return $this;
+						}
+					};
+
+					if ( is_callable( $callback ) ) {
+						$callback( $pipe );
+					}
+
+					return array_map(
+						function ( array $call ) {
+							list( $command, $args ) = $call;
+							$key                    = (string) ( $args[0] ?? '' );
+							switch ( $command ) {
+								case 'smembers':
+									return array_keys( $this->hashes );
+								case 'hmget':
+									$fields = (array) ( $args[1] ?? array() );
+									return array_map( fn( $f ) => $this->hashes[ $key ][ $f ] ?? null, $fields );
+								case 'hkeys':
+									return array_merge( array_keys( $this->hashes[ $key ] ?? array() ), array( 'test:f:post:1' ) );
+								case 'hstrlen':
+									return $this->bodies[ $key ] ?? 0;
+							}
+							return null;
+						},
+						$pipe->queued
+					);
+				}
+
+				public function __call( $command_id, $arguments ) {
+					return null;
+				}
+			};
+
+			$client_prop = new \ReflectionProperty( Storage::class, 'client' );
+			$client_prop->setAccessible( true );
+			$client_prop->setValue( $storage, $stub );
+
+			$entries = $storage->get_entries( 'post:1' );
+
+			expect( array_keys( $entries ) )->toBe( array( 'hashA', 'hashB', 'hashC', 'hashD' ) );
+
+			// Both referrers report the body they point to, and which body that is.
+			expect( $entries['hashA']['size'] )->toBe( 1000 );
+			expect( $entries['hashB']['size'] )->toBe( 1000 );
+			expect( $entries['hashA']['output_hash'] )->toBe( 'body1' );
+			expect( $entries['hashB']['output_hash'] )->toBe( 'body1' );
+			expect( $entries['hashC']['output_hash'] )->toBe( 'body2' );
+			expect( $entries['hashC']['size'] )->toBe( 2000 );
+
+			// The meta size is what an entry weighs on its own.
+			expect( $entries['hashA']['meta_size'] )->toBe( strlen( $stub->hashes['test:c:hashA']['meta'] ) );
+			expect( $entries['hashB']['meta_size'] )->toBe( strlen( $stub->hashes['test:c:hashB']['meta'] ) );
+			expect( $entries['hashB']['meta_size'] )->toBeGreaterThan( $entries['hashA']['meta_size'] );
+
+			// A body-less entry has nothing to share.
+			expect( $entries['hashD']['output_hash'] )->toBe( '' );
+			expect( $entries['hashD']['size'] )->toBe( 0 );
+			expect( $entries['hashD']['meta_size'] )->toBeGreaterThan( 0 );
+
+			expect( array_values( $entries['hashA']['flags'] ) )->toBe( array( 'post:1' ) );
+		} );
+	} );
+
 	describe( 'get_flags_by_pattern', function () {
 		it( 'returns a literal flag as-is without a storage round-trip', function () {
 			$settings = array(


### PR DESCRIPTION
## Why

Bodies live in a content-addressable keyspace, so several cache entries can point at the same body. `Storage::get_entries()` resolved the body length once per unique hash and copied it onto every referrer, but never told the caller which entries share a body. The Pro Entry Browser therefore showed the full body size on every variant and summed a gross total that disagrees with the net size on the Status tab.

## What

Each entry returned by `get_entries()` now carries two more fields:

- `output_hash`: the body the entry references, empty when it has no body.
- `meta_size`: the byte length of the entry's stored metadata JSON, which is already fetched, so this costs no extra round-trip.

`size` is unchanged and still reports the length of the referenced body.

## Follow-up

MilliCache Pro will use both fields to show the body size on one variant per body and only the meta size on variants that share it, and to report a net total in the Entry Browser summary.

## Verification

- `tests/Unit/Core/StorageTest.php` covers two entries sharing a body, one with its own body, and one without a body.
- PHPStan and phpcs pass.